### PR TITLE
Test the MySQL claim path in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,52 @@ jobs:
       - run: python -m pip install --group dev -e . "Django~=${{ matrix.django-version }}.0"
       - run: python -m pytest -q
 
+  # MySQL 8 takes the generic `SELECT ... FOR UPDATE SKIP LOCKED` claim path,
+  # the same branch every non-PostgreSQL database with SKIP LOCKED uses. The
+  # README says the claim path works there, so it is tested rather than assumed.
+  #
+  # A leaner matrix than the other two on purpose: the corners, oldest and
+  # newest supported combination, rather than the full grid. The claim path is
+  # shared with PostgreSQL and already covered six ways there, so the value here
+  # is proving the MySQL adapter and its SQL dialect work at all.
+  #
+  # PyMySQL rather than mysqlclient: no system headers, no compile step, and
+  # tests/settings_mysql.py already registers it under the expected name.
+  test-mysql:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python-version: "3.12"
+            django-version: "6.0"
+          - python-version: "3.14"
+            django-version: "6.1"
+    name: mysql py${{ matrix.python-version }} dj${{ matrix.django-version }}
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ROOT_PASSWORD: ox
+          MYSQL_DATABASE: oxtest
+        ports:
+          - 33069:3306
+        options: >-
+          --health-cmd "mysqladmin ping -h 127.0.0.1 -uroot -pox"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      DJANGO_SETTINGS_MODULE: tests.settings_mysql
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install --group dev -e . "Django~=${{ matrix.django-version }}.0" PyMySQL
+      - run: python -m pytest -q
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -68,8 +68,7 @@ away, however long the work behind it takes.
 
 ```python
 @task
-def process_payment_event(event_id):
-    ...
+def process_payment_event(event_id): ...
 
 
 @csrf_exempt

--- a/tests/settings_mysql.py
+++ b/tests/settings_mysql.py
@@ -1,0 +1,40 @@
+from .settings import *  # noqa: F403
+
+# MySQL 8 verification settings. MySQL 8 supports SELECT ... FOR UPDATE SKIP
+# LOCKED, so the worker takes the same claim path it uses on PostgreSQL's
+# non-single-statement branch rather than the compare-and-set fallback.
+#
+# Expects a disposable server, e.g.:
+#   docker run -d --name ox-mysql -e MYSQL_ROOT_PASSWORD=ox \
+#       -e MYSQL_DATABASE=oxtest -p 33069:3306 mysql:8
+#
+# Django's MySQL backend wants mysqlclient. PyMySQL works too once registered
+# under the same name, which avoids needing a compiler and the MySQL client
+# headers just to run the suite locally.
+try:  # pragma: no cover - environment shim, not behaviour
+    import MySQLdb  # noqa: F401
+except ModuleNotFoundError:  # pragma: no cover
+    try:
+        import pymysql
+
+        pymysql.install_as_MySQLdb()
+    except ModuleNotFoundError:
+        pass
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.mysql",
+        "NAME": "oxtest",
+        "USER": "root",
+        "PASSWORD": "ox",
+        "HOST": "127.0.0.1",
+        "PORT": "33069",
+        "OPTIONS": {
+            # Without STRICT_TRANS_TABLES, MySQL silently truncates rather than
+            # raising, which would hide real bugs behind passing tests.
+            "init_command": "SET sql_mode='STRICT_TRANS_TABLES'",
+            "charset": "utf8mb4",
+        },
+        "TEST": {"CHARSET": "utf8mb4", "COLLATION": "utf8mb4_unicode_ci"},
+    }
+}


### PR DESCRIPTION
The README states that tasks are claimed with `SELECT ... FOR UPDATE SKIP LOCKED` on PostgreSQL and MySQL 8+, but CI only covered PostgreSQL and SQLite. This adds MySQL 8 so that claim is tested rather than asserted.

MySQL takes the generic `SKIP LOCKED` branch, the same one used by every non-PostgreSQL database with that support. Django's own version floor is MySQL 8.0.11 and MariaDB 10.6, and both have `SKIP LOCKED`, so the branch is reachable on any version Django will connect to.

Deliberately a leaner matrix than the other two jobs: the oldest and newest supported combinations rather than the full grid, since the claim branch is already covered six ways by the PostgreSQL job. PyMySQL rather than mysqlclient, so there is no compile step or client headers to install.

Opened as a pull request rather than pushed to `main` because this job has never run. If it fails, it fails here.