### PR TITLE
Pro page: say what Pro is, not what it was going to be

### DIFF
--- a/docs/pro.md
+++ b/docs/pro.md
@@ -1,38 +1,53 @@
 # Pro
 
-Everything documented on this site is free, open source (BSD 3-Clause),
-and stays that way. The durable queue, transactional enqueue, retries,
-reaper, graceful drain, priorities, deferred tasks, recurring tasks and
-pruning are the free tier, permanently.
+Everything documented on this site is free, open source (BSD 3-Clause), and
+stays that way. The durable queue, transactional enqueue, retries, reaper,
+graceful drain, priorities, deferred tasks, recurring tasks and pruning are
+the free tier, permanently. Nothing that works today moves behind the paid
+tier.
 
-**django-ox Pro** is a paid tier in development for the problems that
-only show up at scale. This page is the roadmap, so you can decide
-whether to follow along.
+**Oxpull Pro** is a paid add-on for two problems that show up once a queue is
+carrying real volume. Both are built and tested. It is not on sale yet: the
+purchase and delivery path is still being set up, and the waitlist below is
+how to hear when it opens.
 
-## Planned features
+## What Pro adds
 
-- **Batches**: enqueue N tasks, track them as one unit.
-- **Unique tasks**: deduplicate enqueues so a job cannot be queued twice.
-- **Rate limiting**: per-queue and per-task throughput caps.
-- **Metrics export**: Prometheus and OpenTelemetry.
-- **Email support** from the maintainers.
+- **Unique tasks.** Deduplicate at enqueue time, so the same job cannot be
+  queued twice. The lock is written in the same transaction as the task, so
+  the two commit or roll back together, and a lock whose task died is
+  released rather than stranded.
+- **Batches.** Enqueue a group, read its progress as a count, and fire a
+  callback once every member has settled. Completion is computed by querying
+  the task rows rather than by counting signals, so a worker dying mid-task
+  cannot strand a batch: the reconciler picks it up on the next tick.
 
-Further out, after launch: workflows and chains (tasks that depend on tasks),
-a web dashboard, and encrypted task payloads for teams that need them.
+Both run on the databases the free tier supports: SQLite, PostgreSQL, MySQL
+and MariaDB. Batches are tested to 100,000 members in a single batch.
 
-Delivery will be a license-keyed private package index: `pip install`
-with your key, no vendoring, no source access ceremony.
+## What Pro is not
+
+Rate limiting, workflows and chains, a web dashboard and encrypted payloads
+are not in Pro and are not dated. Metrics stay free: the stats API and the
+health command are in the open source package and remain there.
+
+## Delivery
+
+Pro will install from a private package index using credentials issued per
+company. There is no licence key and no runtime check. A licence check is one
+more thing of ours that can break your production, so we did not build one.
+The credential controls access to the index rather than to code you have
+already installed, so if it lapses, what is deployed keeps running.
 
 ## Pricing
 
-Launch pricing will be **$399 per year, per company**, flat, self-serve.
-One license covers your whole organization and all environments.
-Seven-day money-back.
+Planned at **$399 per year, per company**, flat. One licence to cover a whole
+organisation and every environment, with a seven-day money-back period.
 
 ## Waitlist
 
-If any of the above would earn its keep in your deployment, join the
-waitlist and say which feature. That ordering decides what gets built
-first.
+If Pro would earn its keep in your deployment, join the waitlist and say which
+of the two features matters to you. That ordering decides what gets built
+after these.
 
 [Join the Pro waitlist](https://oxpull.github.io/){ .md-button }


### PR DESCRIPTION
The live page was written when Pro was a roadmap. Five things on it are no longer true, and two of them would contradict the sales material.

- Batches and unique tasks are listed under **Planned features**. Both ship.
- Pro is described as "in development". It is built, reviewed, CI-green on three databases, soaked, and tested to 100,000 members in a batch.
- **Rate limiting and metrics export are promised as Pro features.** Neither is in Pro. Metrics are free and stay free. A page promising more than the product is the one direction a pricing page must not be wrong in.
- Delivery is described as a "license-keyed private package index". There is no licence key and no runtime check, deliberately, and that is worth saying plainly.

This version says Pro is built but **not yet on sale**, because the purchase and delivery path is not up, and keeps the waitlist as the call to action. Price appears as planned, which qualifies the waitlist without implying a checkout exists. Nothing here becomes false when the index goes live; only the closing section gets swapped for a purchase path.

Gates run locally: copy-lint 0 errors, leak-scan 81 tracked files / 0 findings, `mkdocs build --strict` exit 0.