### PR TITLE
Point the canonical URLs at the real domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://oxpull.github.io/django-ox/assets/lockup.png" alt="django-ox" width="380">
+<img src="https://oxpull.com/django-ox/assets/lockup.png" alt="django-ox" width="380">
 
 [![PyPI](https://img.shields.io/pypi/v/django-ox)](https://pypi.org/project/django-ox/)
 [![CI](https://github.com/oxpull/django-ox/actions/workflows/ci.yml/badge.svg)](https://github.com/oxpull/django-ox/actions/workflows/ci.yml)
@@ -7,7 +7,7 @@
 
 A database-backed worker backend for Django's Tasks framework (`django.tasks`, Django 6.0+).
 
-Documentation: <https://oxpull.github.io/django-ox/>
+Documentation: <https://oxpull.com/django-ox/>
 
 Django 6.0 ships the Tasks API but no production backend: the built-in
 `ImmediateBackend` and `DummyBackend` are for development and testing only.
@@ -234,14 +234,14 @@ scope: task revocation after enqueue, and multi-database routing (tasks
 are stored on the default database for the model).
 
 Batches, unique tasks, rate limiting, and metrics export are planned in
-[Oxpull Pro](https://oxpull.github.io/django-ox/pro/); the waitlist is at
-<https://oxpull.github.io/>.
+[Oxpull Pro](https://oxpull.com/django-ox/pro/); the waitlist is at
+<https://oxpull.com/>.
 
 ## Stability
 
 What counts as public API, the pre-1.0 versioning and deprecation policy,
 and the supported Python and Django versions are documented in
-[the stability policy](https://oxpull.github.io/django-ox/stability/).
+[the stability policy](https://oxpull.com/django-ox/stability/).
 
 ## License
 

--- a/docs/pro.md
+++ b/docs/pro.md
@@ -50,4 +50,4 @@ If Pro would earn its keep in your deployment, join the waitlist and say which
 of the two features matters to you. That ordering decides what gets built
 after these.
 
-[Join the Pro waitlist](https://oxpull.github.io/){ .md-button }
+[Join the Pro waitlist](https://oxpull.com/){ .md-button }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: django-ox
 site_description: Database-backed worker backend for Django's Tasks framework.
-site_url: https://oxpull.github.io/django-ox/
+site_url: https://oxpull.com/django-ox/
 repo_url: https://github.com/oxpull/django-ox
 
 exclude_docs: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 
 [project.urls]
 Homepage = "https://github.com/oxpull/django-ox"
-Documentation = "https://oxpull.github.io/django-ox/"
+Documentation = "https://oxpull.com/django-ox/"
 Repository = "https://github.com/oxpull/django-ox"
 Changelog = "https://github.com/oxpull/django-ox/blob/main/CHANGELOG.md"
 Issues = "https://github.com/oxpull/django-ox/issues"

--- a/tools/check_release.py
+++ b/tools/check_release.py
@@ -32,7 +32,11 @@ from urllib.parse import urlparse
 REPO = Path(__file__).resolve().parent.parent
 
 EXPECTED_URL_KEYS = {"Homepage", "Documentation", "Repository", "Changelog", "Issues"}
-ALLOWED_HOSTS = {"github.com", "oxpull.github.io", "pypi.org"}
+# The hosts a project URL may point at. This is an allowlist on purpose: a
+# release is permanent, so a URL that drifts to an unexpected host has to
+# fail here rather than ship. oxpull.com became the canonical site on
+# 2026-08-19; oxpull.github.io stays because it still serves and redirects.
+ALLOWED_HOSTS = {"github.com", "oxpull.com", "oxpull.github.io", "pypi.org"}
 
 
 def fail(message: str) -> str:


### PR DESCRIPTION
`oxpull.com` now serves the site over HTTPS, with the docs at `oxpull.com/django-ox/`. This updates the places that still named the `github.io` address.

- `mkdocs.yml` `site_url`, which drives the sitemap and the canonical link tags. This is the one that matters: canonical URLs disagreeing with the address people reach splits the site's identity for anything that indexes it.
- README links and the banner image.
- `pyproject.toml` Documentation URL, which applies from the next release.
- The Pro page waitlist button.

Every URL written here was fetched first and returned 200. The old `github.io` links keep working via GitHub's redirect, so nothing that references them breaks, including the published PyPI page whose metadata cannot be edited.

Gates: copy-lint 0 errors, leak-scan 81 files / 0 findings, `mkdocs build --strict` exit 0.