### PR TITLE
Align the Pro scope described across the docs

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -153,8 +153,8 @@ them. Everything a dashboard usually wants survives at INFO.
   `failure_rate` rising above your normal baseline. Throughput is better
   as a dashboard line than an alert: its healthy value depends entirely
   on offered load.
-- **Prometheus.** No exporter ships with the core; that is a
-  [Pro](pro.md) feature. The stats functions drop into any Django metrics setup
+- **Prometheus.** No exporter ships with django-ox, and none ships in
+  [Pro](pro.md) either. The stats functions drop into any Django metrics setup
   though. Either register a custom collector with django-prometheus, whose
   `collect()` calls `queue_stats()`, `ready_count()` and `oldest_ready_age()`
   and yields gauges, or render the same numbers from a plain Django view in the

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -221,6 +221,7 @@ to exercise claiming and retries for real.
 
 ## Not in the core
 
-Batches, unique or deduplicated tasks, rate limiting and metrics export are not
-part of django-ox. They are the [Oxpull Pro](pro.md) feature set. Chains and
-workflows are on that roadmap and do not exist yet in either tier.
+Batches and unique or deduplicated tasks are not part of django-ox. They are the
+[Oxpull Pro](pro.md) feature set. Metrics are in the free tier: `django_ox.stats`
+and `manage.py ox_health` ship in the core. Rate limiting, chains and workflows
+do not exist in either tier.

--- a/docs/pro.md
+++ b/docs/pro.md
@@ -22,8 +22,9 @@ how to hear when it opens.
   the task rows rather than by counting signals, so a worker dying mid-task
   cannot strand a batch: the reconciler picks it up on the next tick.
 
-Both run on the databases the free tier supports: SQLite, PostgreSQL, MySQL
-and MariaDB. Batches are tested to 100,000 members in a single batch.
+Both run on the databases the free tier tests in CI: SQLite, PostgreSQL and
+MySQL 8. MariaDB 10.6+ takes the same claim path but is not part of the tested
+matrix. Batches are tested to 100,000 members in a single batch.
 
 ## What Pro is not
 
@@ -50,4 +51,4 @@ If Pro would earn its keep in your deployment, join the waitlist and say which
 of the two features matters to you. That ordering decides what gets built
 after these.
 
-[Join the Pro waitlist](https://oxpull.com/){ .md-button }
+[Join the Pro waitlist](https://oxpull.com/#waitlist){ .md-button }


### PR DESCRIPTION
The monitoring, patterns and Pro pages each described the paid tier differently. They now match, and match the tier itself.

- **Prometheus.** No exporter ships in either tier. The stats functions are free and drop into any Django metrics setup.
- **Rate limiting.** Not in either tier today.
- **Metrics.** Free. `django_ox.stats` and `ox_health` are in this package and stay here.
- **Databases.** SQLite, PostgreSQL and MySQL 8 are tested in CI. MariaDB 10.6+ takes the same claim path but is not in the tested matrix, which is what `docs/stability.md` already said.

The Pro page's waitlist button linked to the site root rather than to the waitlist form. It now links to the form.