### PR TITLE
Name Oxpull in the BSD 3-Clause copyright line

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2026, [COMPANY]
+Copyright (c) 2026, Oxpull
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
The BSD 3-Clause copyright line now names Oxpull.

Published artifacts are immutable, so this takes effect from the next release.