### PR TITLE
Describe the paid tier the same way everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,9 +233,10 @@ schedules, monitoring, and nothing else to operate. Outside the current
 scope: task revocation after enqueue, and multi-database routing (tasks
 are stored on the default database for the model).
 
-Batches, unique tasks, rate limiting, and metrics export are planned in
-[Oxpull Pro](https://oxpull.com/django-ox/pro/); the waitlist is at
-<https://oxpull.com/>.
+Batches and unique tasks ship in [Oxpull Pro](https://oxpull.com/django-ox/pro/);
+the waitlist is at <https://oxpull.com/>. Metrics stay in this package:
+`django_ox.stats` and `ox_health` are free and stay free. Rate limiting is in
+neither tier.
 
 ## Stability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -55,8 +55,8 @@ backup, or those log records can read them.
 - Tracebacks are standard `traceback.format_exception()` output: stack
   frames and the exception message, without local-variable values.
 
-Encrypting arguments at rest is on the Oxpull Pro roadmap; the plaintext
-posture above is what the open-source package does.
+Encrypting arguments at rest is not offered in either tier today; the plaintext
+posture above is what both packages do.
 
 ## SQL
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -160,8 +160,9 @@ decisions worth knowing before you commit:
   CPU-bound work, run multiple worker processes with `--concurrency 1`
   instead. See [Production](production.md#threads-and-processes).
 
-Batches, unique tasks, rate limiting, and metrics export are on the
-[Pro roadmap](pro.md).
+Batches and unique tasks ship in [Oxpull Pro](pro.md). Metrics stay in this
+package: `django_ox.stats` and `ox_health` are free and stay free. Rate limiting
+is in neither tier.
 
 ## License
 


### PR DESCRIPTION
The README, the documentation home page and the security policy each still described the paid tier as a roadmap.

Batches and unique tasks ship in it today. Metrics are free and stay free: `django_ox.stats` and `ox_health` are in this package. Rate limiting is in neither tier.

The README is the package page on PyPI, so it was the most read of the three, and it understated the product while repeating two claims corrected elsewhere.

`SECURITY.md` said encrypting arguments at rest is on the paid roadmap. It is not offered in either tier, and the plaintext posture it describes is what both packages do.

This covers the pages #12 did not reach. Together they leave every surface saying the same thing.

Gates: `copy_lint.py` 0 errors, `leak_scan.py` 81 files 0 findings, `mkdocs build --strict` clean.