### PR TITLE
Release 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.1] - 2026-08-24
 
+### Fixed
+
+- `ox_worker --processes N` exits 0 when a stop signal arrives while a
+  worker process is still starting up. A worker cannot act on a signal
+  until it has installed its handler, and that is after Django has been
+  imported. A signal landing before then killed the worker outright, and
+  the supervisor reported that worker's 143 as its own exit code. A unit
+  on `Restart=on-failure` reads that as a fault and starts the service
+  again. The worker had claimed no work, so there is nothing to report:
+  the supervisor now logs `worker_process_stopped_early` and exits 0.
+
 ### Changed
 
 - A worker enforces `TASK_TIMEOUT` on a sync task through the grace backstop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.1] - 2026-08-24
 
 ### Changed
 
@@ -323,7 +323,7 @@ Initial release.
   the public API surface, the pre-1.0 SemVer rule, the deprecation
   window, and the supported Python and Django matrix.
 
-[Unreleased]: https://github.com/oxpull/django-ox/compare/v0.3.0...HEAD
+[0.3.1]: https://github.com/oxpull/django-ox/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/oxpull/django-ox/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/oxpull/django-ox/releases/tag/v0.2.1
 [0.2.0]: https://github.com/oxpull/django-ox/releases/tag/v0.2.0

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2394,7 +2394,7 @@ the pre-1.0 rule applies:
 - **0.x.y patch releases are bug fixes only** and never break a public
   surface.
 
-Pin accordingly: `django-ox~=0.3.0` accepts patch releases only;
+Pin accordingly: `django-ox~=0.3.1` accepts patch releases only;
 `django-ox>=0.3,<0.4` accepts the current minor line.
 
 Once 1.0 ships, breaking changes to the public API will require a major
@@ -2725,7 +2725,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.1] - 2026-08-24
 
 ### Changed
 
@@ -3043,7 +3043,7 @@ Initial release.
   the public API surface, the pre-1.0 SemVer rule, the deprecation
   window, and the supported Python and Django matrix.
 
-[Unreleased]: https://github.com/oxpull/django-ox/compare/v0.3.0...HEAD
+[0.3.1]: https://github.com/oxpull/django-ox/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/oxpull/django-ox/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/oxpull/django-ox/releases/tag/v0.2.1
 [0.2.0]: https://github.com/oxpull/django-ox/releases/tag/v0.2.0

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1352,7 +1352,12 @@ counts as well as SIGTERM and SIGINT. The sequence is:
 
 1. First signal: the supervisor forwards SIGTERM to every worker process
    and waits for each to drain. It exits 0 when all of them did, otherwise
-   with the first non-zero code.
+   with the first non-zero code. A worker process cannot act on a signal
+   until it has installed its handler, which is after Django is imported,
+   so a stop that lands in that window kills it outright. It had claimed
+   no work, so the supervisor logs `worker_process_stopped_early` and
+   still exits 0. A restart, or a deploy that rolls twice, is not a
+   failure to report to the process manager.
 2. Second signal: forwarded again, which is the force-exit on each worker.
    A worker that cannot act on it (stopped, stuck in a C call) gets five
    seconds, then SIGKILL, logged as `supervisor_killed_workers` at ERROR.
@@ -2065,6 +2070,7 @@ The message text is not part of the contract. The keys are.
 | `supervisor_started` | INFO | `ox_worker --processes N` started its worker processes. |
 | `worker_process_restarted` | WARNING | A worker process exited on its own and is being restarted. |
 | `worker_process_recycled` | WARNING | A worker process exited with code 75 after a stuck task thread and is being restarted. Not counted against the restart cap. |
+| `worker_process_stopped_early` | INFO | A stop signal reached a worker process before it had finished starting, so it died on the signal rather than draining. It had claimed no work, and the supervisor does not count it as a failure. |
 | `supervisor_restart_cap` | ERROR | More than five deaths of one slot in a minute; the supervisor is stopping with exit code 1. |
 | `supervisor_killed_workers` | ERROR | Worker processes still running five seconds after the second stop signal were sent SIGKILL. |
 | `supervisor_stopped` | INFO | Every worker process has exited. |
@@ -2726,6 +2732,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.3.1] - 2026-08-24
+
+### Fixed
+
+- `ox_worker --processes N` exits 0 when a stop signal arrives while a
+  worker process is still starting up. A worker cannot act on a signal
+  until it has installed its handler, and that is after Django has been
+  imported. A signal landing before then killed the worker outright, and
+  the supervisor reported that worker's 143 as its own exit code. A unit
+  on `Restart=on-failure` reads that as a fault and starts the service
+  again. The worker had claimed no work, so there is nothing to report:
+  the supervisor now logs `worker_process_stopped_early` and exits 0.
 
 ### Changed
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -258,6 +258,7 @@ The message text is not part of the contract. The keys are.
 | `supervisor_started` | INFO | `ox_worker --processes N` started its worker processes. |
 | `worker_process_restarted` | WARNING | A worker process exited on its own and is being restarted. |
 | `worker_process_recycled` | WARNING | A worker process exited with code 75 after a stuck task thread and is being restarted. Not counted against the restart cap. |
+| `worker_process_stopped_early` | INFO | A stop signal reached a worker process before it had finished starting, so it died on the signal rather than draining. It had claimed no work, and the supervisor does not count it as a failure. |
 | `supervisor_restart_cap` | ERROR | More than five deaths of one slot in a minute; the supervisor is stopping with exit code 1. |
 | `supervisor_killed_workers` | ERROR | Worker processes still running five seconds after the second stop signal were sent SIGKILL. |
 | `supervisor_stopped` | INFO | Every worker process has exited. |

--- a/docs/production.md
+++ b/docs/production.md
@@ -137,7 +137,12 @@ counts as well as SIGTERM and SIGINT. The sequence is:
 
 1. First signal: the supervisor forwards SIGTERM to every worker process
    and waits for each to drain. It exits 0 when all of them did, otherwise
-   with the first non-zero code.
+   with the first non-zero code. A worker process cannot act on a signal
+   until it has installed its handler, which is after Django is imported,
+   so a stop that lands in that window kills it outright. It had claimed
+   no work, so the supervisor logs `worker_process_stopped_early` and
+   still exits 0. A restart, or a deploy that rolls twice, is not a
+   failure to report to the process manager.
 2. Second signal: forwarded again, which is the force-exit on each worker.
    A worker that cannot act on it (stopped, stuck in a C call) gets five
    seconds, then SIGKILL, logged as `supervisor_killed_workers` at ERROR.

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -85,7 +85,7 @@ the pre-1.0 rule applies:
 - **0.x.y patch releases are bug fixes only** and never break a public
   surface.
 
-Pin accordingly: `django-ox~=0.3.0` accepts patch releases only;
+Pin accordingly: `django-ox~=0.3.1` accepts patch releases only;
 `django-ox>=0.3,<0.4` accepts the current minor line.
 
 Once 1.0 ships, breaking changes to the public API will require a major

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-ox"
-version = "0.3.0"
+version = "0.3.1"
 description = "Database-backed worker backend for Django's Tasks framework."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/src/django_ox/__init__.py
+++ b/src/django_ox/__init__.py
@@ -1,4 +1,4 @@
 from .timeouts import deadline, remaining
 
 __all__ = ["__version__", "deadline", "remaining"]
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/src/django_ox/supervisor.py
+++ b/src/django_ox/supervisor.py
@@ -14,7 +14,9 @@ in ``ps``.
 The supervisor never opens a database connection. It starts the children,
 forwards SIGTERM, SIGINT and SIGHUP to them, restarts a slot that dies while
 the supervisor is not stopping, and exits with the children's worst exit
-code, or 1 when a slot tripped the restart cap.
+code, or 1 when a slot tripped the restart cap. A child that the forwarded
+SIGTERM killed before it had installed its own handler is not one of those
+codes: see _record_exit.
 """
 
 import logging
@@ -187,6 +189,36 @@ class Supervisor:
                 with suppress(ProcessLookupError):
                     proc.send_signal(signum)
 
+    def _record_exit(self, index: int, code: int) -> None:
+        """
+        Record how one slot ended, as the supervisor's own exit code sees it.
+
+        A child dies *from* SIGTERM only in the window between its exec and
+        the moment it installs its handler; from there on the signal drains
+        it and it exits 0. So a child that died this way, while the
+        supervisor was stopping, was killed by the SIGTERM the supervisor
+        itself had just forwarded, before it had opened a database
+        connection or claimed a task. Nothing was lost and nothing failed.
+
+        Reporting it upwards would say otherwise. A stop that lands during
+        startup is ordinary -- a restart, a deploy that rolls twice, a
+        health check that never went green -- and a unit on
+        ``Restart=on-failure`` would read the 143 as a fault and start the
+        service again.
+        """
+        if self._stopping and code == -signal.SIGTERM:
+            logger.info(
+                "Worker process %d was still starting when it was stopped; "
+                "it had claimed no work",
+                index,
+                extra={
+                    "event": "worker_process_stopped_early",
+                    "worker_index": index,
+                },
+            )
+            code = 0
+        self._exit_codes[index] = code
+
     def _next_delay(self, index: int, now: float) -> float:
         """The restart delay for this death of ``index``, with backoff."""
         lived = now - self._started_at.get(index, now)
@@ -203,7 +235,7 @@ class Supervisor:
             if code is None:
                 continue
             del self._children[index]
-            self._exit_codes[index] = code
+            self._record_exit(index, code)
             if self._stopping:
                 continue
             now = time.monotonic()
@@ -353,7 +385,7 @@ class Supervisor:
             self.request_stop()
             self._signal_children(signal.SIGTERM)
             for index, proc in self._children.items():
-                self._exit_codes[index] = proc.wait()
+                self._record_exit(index, proc.wait())
             self._children.clear()
         # A recycle that lands during a stop is a worker that finished the
         # job it was asked to do, not a failure to report upwards.

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -63,7 +63,7 @@ TASKS: dict[str, dict[str, Any]] = {
     }
 }
 
-LOGGING = {
+LOGGING: dict[str, Any] = {
     "version": 1,
     "disable_existing_loggers": False,
     "handlers": {"console": {"class": "logging.StreamHandler"}},
@@ -76,6 +76,18 @@ LOGGING = {
         },
     },
 }
+
+# Worker processes a test starts in-process, through Supervisor rather than
+# through a subprocess of its own, inherit the test runner's stderr and there
+# is nowhere to read their lifecycle lines from. Given a path, they append to
+# it as well, so a test can wait for a child to be running before it acts.
+if "OX_TEST_LOG_FILE" in os.environ:
+    LOGGING["handlers"]["file"] = {
+        "class": "logging.FileHandler",
+        "filename": os.environ["OX_TEST_LOG_FILE"],
+        "delay": True,
+    }
+    LOGGING["loggers"]["django_ox"]["handlers"].append("file")
 
 # Worker processes started from the test suite must hit the test database the
 # parent created, not the development one; the parent passes its name through.

--- a/tests/test_clock.py
+++ b/tests/test_clock.py
@@ -61,11 +61,20 @@ class TestLeaseClockAgreesWithColumns:
             "offset old, and a delete is not reversible."
         )
 
-    def test_last_claim_age_is_small_and_not_negative(self, worker):
+    def test_last_claim_age_is_small_in_either_direction(self, worker):
+        # The two sides of this reading come from two clocks: timezone.now()
+        # is this process, last_attempted_at was stamped by the database. The
+        # gap between the claim and the reading is a few milliseconds, so a
+        # server whose clock is milliseconds ahead -- one on another host, or
+        # one in a VM that drifts from the host it runs on -- reads as a
+        # negative age for reasons that are nobody's bug. The bound is the
+        # same in both directions for that reason. What it is here to catch
+        # is a whole UTC offset, an hour at the least, and TOLERANCE is
+        # nowhere near an hour either way.
         run_one(worker)
         age = last_claim_age()
         assert age is not None
-        assert timedelta(0) <= age < TOLERANCE, (
+        assert -TOLERANCE < age < TOLERANCE, (
             f"last_claim_age reports {age}, so ox_health --worker-timeout "
             "either always fails or can never fail."
         )

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -62,11 +62,15 @@ def start_worker(
     )
 
 
-def scratch_project(tmp_path: Path) -> Path:
+def scratch_project(tmp_path: Path, startup_delay: float = 0.0) -> Path:
     """
     A project directory with its own manage.py and settings package, the way
     a deployment has one. The settings re-export the test settings so the
     children reach the test database.
+
+    ``startup_delay`` holds the children inside the settings import, which is
+    the window before their signal handlers exist. Only the children: the
+    supervisor's own argv carries no --worker-index.
     """
     project = tmp_path / "proj"
     (project / "scratchproj").mkdir(parents=True)
@@ -80,6 +84,12 @@ def scratch_project(tmp_path: Path) -> Path:
     (project / "scratchproj" / "settings.py").write_text(
         f"import sys\nsys.path.insert(0, {str(REPO)!r})\n"
         f"from {settings.SETTINGS_MODULE} import *  # noqa: F403\n"
+        + (
+            "if '--worker-index' in sys.argv:\n"
+            f"    import time; time.sleep({startup_delay})\n"
+            if startup_delay
+            else ""
+        )
     )
     return project
 
@@ -96,9 +106,18 @@ def slot_pid(supervisor: Supervisor, index: int) -> int | None:
     return proc.pid if proc is not None and proc.poll() is None else None
 
 
-def in_process_env(monkeypatch) -> None:
+def in_process_env(monkeypatch, tmp_path: Path | None = None) -> None:
+    """
+    Give this process the environment a child worker needs, so a Supervisor
+    run from the test itself starts children against the test database.
+
+    With ``tmp_path``, the children also append their lifecycle lines to
+    ``worker.log`` under it, which is what ``wait_for_workers`` reads.
+    """
     for key, value in child_env().items():
         monkeypatch.setenv(key, value)
+    if tmp_path is not None:
+        monkeypatch.setenv("OX_TEST_LOG_FILE", str(tmp_path / "worker.log"))
 
 
 def stop_worker(proc: subprocess.Popen[bytes], tmp_path: Path) -> tuple[int, str]:
@@ -111,6 +130,26 @@ def stop_worker(proc: subprocess.Popen[bytes], tmp_path: Path) -> tuple[int, str
         proc.kill()
         code = proc.wait()
     return code, (tmp_path / "worker.log").read_text()
+
+
+WORKER_STARTED = re.compile(r"Worker \S+ starting: queues=")
+
+
+def wait_for_workers(tmp_path: Path, count: int, timeout: float = 20.0) -> bool:
+    """
+    Wait until ``count`` children have logged the line they log once running.
+
+    Until a child reaches that line it has not installed its signal handler,
+    and a stop lands on the default disposition instead: it dies, having
+    claimed nothing. The supervisor treats that as a clean stop
+    (TestStopDuringStartup), so a test about draining live workers has to
+    wait past the window or it is a test about the window.
+    """
+    log = tmp_path / "worker.log"
+    return wait_for(
+        lambda: log.exists() and len(WORKER_STARTED.findall(log.read_text())) >= count,
+        timeout=timeout,
+    )
 
 
 def child_pids(proc: subprocess.Popen[bytes]) -> list[int]:
@@ -190,16 +229,26 @@ class TestProcessesTwo:
                 ),
                 timeout=20,
             )
+            # A running task proves one child is up. This test is about two
+            # live workers draining, so wait for the second one as well; a
+            # stop during a child's startup is TestStopDuringStartup.
+            assert wait_for_workers(tmp_path, 2)
             pids = child_pids(proc)
             assert len(pids) == 2
         finally:
             code, log = stop_worker(proc, tmp_path)
 
-        assert code == 0
+        assert code == 0, log
         assert not any(alive(pid) for pid in pids)
         assert not OxTask.objects.filter(status=OxTask.Status.RUNNING).exists()
         assert OxTask.objects.get(id=result.id).status == OxTask.Status.SUCCESSFUL
+        # Both children took the signal and drained on it. Without this the
+        # exit code alone cannot tell a drain apart from a child that died
+        # in its startup window, which also exits the supervisor zero.
+        assert len(re.findall(r"Worker \S+ received SIGTERM; draining", log)) == 2
+        assert len(re.findall(r"Worker \S+ stopped", log)) == 2
         assert "worker_process_restarted" not in log
+        # Covers the startup-window line too: it also begins "Worker process".
         assert "Worker process" not in log
 
     @needs_pgrep
@@ -238,10 +287,14 @@ class TestProcessesTwo:
             after = set(child_pids(proc))
             assert len(after) == 2
             assert holder_pid not in after
+            # Three starts: the original two and the replacement. The stop
+            # below is about draining live workers, not about catching the
+            # replacement mid-import.
+            assert wait_for_workers(tmp_path, 3)
         finally:
             code, log = stop_worker(proc, tmp_path)
 
-        assert code == 0
+        assert code == 0, log
         assert re.search(
             r"Worker process \d exited with signal SIGKILL; restarting", log
         )
@@ -263,27 +316,15 @@ class TestReinvocation:
                 ),
                 timeout=20,
             )
-            # Both children must be past their import window, handlers
-            # installed, before the stop: a SIGTERM that lands while a
-            # child is still importing Django kills it with 143.
-            assert wait_for(
-                lambda: (
-                    len(
-                        re.findall(
-                            r"Worker \S+ starting: queues=",
-                            (tmp_path / "worker.log").read_text(),
-                        )
-                    )
-                    == 2
-                ),
-                timeout=20,
-            )
+            # Both children live before the stop: this test is about two
+            # reinvoked workers, so it has to see two of them.
+            assert wait_for_workers(tmp_path, 2)
         finally:
             code, log = stop_worker(proc, tmp_path)
         assert code == 0, log
         assert "ModuleNotFoundError" not in log
         assert "Worker process" not in log
-        assert len(re.findall(r"Worker \S+ starting: queues=", log)) == 2
+        assert len(WORKER_STARTED.findall(log)) == 2
 
     def test_absolute_manage_py_from_another_cwd(self, tmp_path):
         project = scratch_project(tmp_path)
@@ -319,6 +360,76 @@ class TestReinvocation:
             env=env,
         )
         self._runs_two_workers(tmp_path, proc)
+
+
+class TestStopDuringStartup:
+    """
+    A child cannot act on a signal until it has installed its handler, and
+    that is after Django has been imported. A stop that lands before then
+    kills the child outright, on the default disposition, with the very
+    SIGTERM the supervisor forwarded.
+
+    That window is not a test artefact. Anything that stops a service
+    shortly after starting it -- a restart, a deploy that rolls twice, a
+    health check that never goes green -- lands in it. The supervisor used
+    to report the child's 143 as its own exit code, which a unit on
+    ``Restart=on-failure`` reads as a fault and starts again.
+    """
+
+    # How long the children sit inside their settings import. The stop is
+    # sent as soon as both child processes exist, so this only has to
+    # outlast one pgrep; a slower machine makes the test more certain, not
+    # less. Nothing waits it out: the children die inside it.
+    IMPORT_SECONDS = 15.0
+
+    @needs_pgrep
+    def test_a_stop_in_the_startup_window_is_not_a_failure(self, tmp_path):
+        project = scratch_project(tmp_path, startup_delay=self.IMPORT_SECONDS)
+        env = child_env()
+        del env["DJANGO_SETTINGS_MODULE"]
+        proc = start_worker(
+            tmp_path,
+            "--pythonpath",
+            str(project),
+            "--settings",
+            "scratchproj.settings",
+            "--processes",
+            "2",
+            "--interval",
+            "0.05",
+            cwd=Path("/"),
+            env=env,
+        )
+        try:
+            assert wait_for(lambda: len(child_pids(proc)) == 2, timeout=20)
+            pids = child_pids(proc)
+        finally:
+            code, log = stop_worker(proc, tmp_path)
+
+        assert code == 0, log
+        # The window is what was tested: neither child ever got as far as
+        # the line it logs once it is running, so neither could have
+        # handled the signal.
+        assert not WORKER_STARTED.search(log), log
+        assert log.count("was still starting when it was stopped") == 2, log
+        assert not any(alive(pid) for pid in pids)
+        assert "worker_process_restarted" not in log
+
+    def test_a_child_killed_outside_a_stop_is_still_a_failure(self):
+        """
+        The rule is about the supervisor's own signal, not about 143 in
+        general. A worker something else killed is a death like any other.
+        """
+        supervisor = Supervisor(processes=1, worker_args=[])
+        supervisor._record_exit(0, -signal.SIGTERM)
+        assert supervisor._exit_codes == {0: -signal.SIGTERM}
+
+        supervisor.request_stop()
+        supervisor._record_exit(0, -signal.SIGTERM)
+        assert supervisor._exit_codes == {0: 0}
+        # A child that ignored the signal and had to be killed still counts.
+        supervisor._record_exit(1, -signal.SIGKILL)
+        assert supervisor._exit_codes[1] == -signal.SIGKILL
 
 
 class TestRestartCap:
@@ -365,8 +476,11 @@ class TestRestartCap:
         assert cap[0].worker_index == 0
         assert cap[0].exit_code == 0
 
-    def test_every_slot_dying_at_once_is_one_restart_each(self, monkeypatch):
-        in_process_env(monkeypatch)
+    def test_every_slot_dying_at_once_is_one_restart_each(
+        self, caplog, monkeypatch, tmp_path
+    ):
+        caplog.set_level(logging.WARNING, logger="django_ox")
+        in_process_env(monkeypatch, tmp_path)
         supervisor = Supervisor(
             processes=4,
             worker_args=["--interval", "0.05", "--verbosity", "0"],
@@ -374,9 +488,10 @@ class TestRestartCap:
         )
         thread, result = run_in_thread(supervisor)
         try:
-            assert wait_for(
-                lambda: all(slot_pid(supervisor, i) for i in range(4)), timeout=20
-            )
+            # Four running workers, not four processes that exist: what is
+            # under test is what the supervisor does when live slots die
+            # together.
+            assert wait_for_workers(tmp_path, 4)
             before = [slot_pid(supervisor, i) for i in range(4)]
             for pid in before:
                 os.kill(pid, signal.SIGKILL)
@@ -388,12 +503,19 @@ class TestRestartCap:
             )
             assert thread.is_alive()
             assert not supervisor.stopping
-            time.sleep(1.0)  # let the new children install their signal handlers
+            # Eight starts: four originals and four replacements. The drain
+            # below is the claim being tested, so it has to find four live
+            # workers rather than four that are still importing.
+            assert wait_for_workers(tmp_path, 8)
         finally:
             supervisor.request_stop()
             supervisor._signal_children(signal.SIGTERM)
             thread.join(timeout=20)
         assert result == [0]
+        # Four deaths, four restarts: one each, not a slot counted twice.
+        events = [getattr(r, "event", None) for r in caplog.records]
+        assert events.count("worker_process_restarted") == 4
+        assert events.count("supervisor_restart_cap") == 0
 
     def test_one_slot_over_the_cap_stops_the_supervisor(self, caplog, monkeypatch):
         caplog.set_level(logging.WARNING, logger="django_ox")
@@ -537,10 +659,10 @@ class TestOrphans:
 
 class TestEscalation:
     def test_second_signal_kills_a_stuck_child_after_the_grace(
-        self, caplog, monkeypatch
+        self, caplog, monkeypatch, tmp_path
     ):
         caplog.set_level(logging.INFO, logger="django_ox")
-        in_process_env(monkeypatch)
+        in_process_env(monkeypatch, tmp_path)
         supervisor = Supervisor(
             processes=2,
             worker_args=["--interval", "0.05", "--verbosity", "0"],
@@ -552,7 +674,10 @@ class TestEscalation:
             assert wait_for(
                 lambda: all(slot_pid(supervisor, i) for i in range(2)), timeout=20
             )
-            time.sleep(1.0)  # let the children install their signal handlers
+            # Both children running, handlers installed: what is under test
+            # is a worker that will not act on a signal it can receive, not
+            # one that never reached the point of receiving it.
+            assert wait_for_workers(tmp_path, 2)
             stuck = slot_pid(supervisor, 0)
             os.kill(stuck, signal.SIGSTOP)
             started = time.monotonic()

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -278,6 +278,23 @@ def run_in_thread(worker):
     return start_worker_thread(worker)
 
 
+def assert_stopped_at_the_deadline(elapsed, *, timeout, task_seconds):
+    """
+    The claim every timeout test here makes about the clock: the worker came
+    back before the task would have finished on its own.
+
+    That is the whole proposition, and the task's own duration is the only
+    bound that states it. A number picked somewhere between the deadline and
+    the task's end reads as tighter but proves nothing more, and it fails on
+    a machine that is merely slow: a loaded runner under a coverage tracer
+    can spend a second on the claim and the result write alone.
+    """
+    # A task that would end before its own deadline says nothing about the
+    # deadline; the bound below has to have something to cut short.
+    assert timeout < task_seconds, (timeout, task_seconds)
+    assert elapsed < task_seconds, (elapsed, task_seconds)
+
+
 def row(result):
     return OxTask.objects.get(id=result.id)
 
@@ -516,20 +533,32 @@ class TestOptions:
 
 @pytest.mark.django_db(transaction=True)
 class TestSoftTimeout:
-    def _timed_out(self, task=spin, seconds=2.0, timeout=0.2, **kwargs):
+    # The deadline under test, and how long these tasks would run without
+    # one. Every bound in this class is one of the two: what is asserted is
+    # that the worker returns at the deadline rather than at the task's own
+    # end, and those are the only numbers that say it.
+    TIMEOUT = 0.2
+    TASK_SECONDS = 2.0
+
+    def _timed_out(self, task=spin, seconds=None, **kwargs):
+        seconds = self.TASK_SECONDS if seconds is None else seconds
+        kwargs.setdefault("task_timeout", self.TIMEOUT)
         worker = Worker(backoff_initial=60, poll_interval=0.05, **kwargs)
         result = task.enqueue(seconds)
         started = time.monotonic()
         assert worker.run_once()
-        elapsed = time.monotonic() - started
-        return worker, result, elapsed
+        # The task stopped at the deadline, not when its own loop ended.
+        assert_stopped_at_the_deadline(
+            time.monotonic() - started,
+            timeout=kwargs["task_timeout"],
+            task_seconds=seconds,
+        )
+        return worker, result
 
     def test_raised_inside_the_task_and_recorded(
         self, task_state, interruptible_attempts
     ):
-        worker, result, elapsed = self._timed_out(task_timeout=0.2)
-        # The task stopped at the deadline, not when its loop ended.
-        assert elapsed < 1.0
+        worker, result = self._timed_out()
         assert task_state.get("caught") is True
         assert task_state.get("finally_ran") is True
 
@@ -564,7 +593,7 @@ class TestSoftTimeout:
         assert result.errors[-1].exception_class is TaskTimeout
 
     def test_retried_on_the_backoff_and_not_before(self, interruptible_attempts):
-        worker, result, _ = self._timed_out(task_timeout=0.2)
+        worker, result = self._timed_out()
         assert not worker.run_once()
         assert row(result).attempts == 1
         OxTask.objects.filter(id=result.id).update(run_after=None)
@@ -573,11 +602,11 @@ class TestSoftTimeout:
 
     def test_logs_the_timeout_event(self, caplog, interruptible_attempts):
         caplog.set_level(logging.WARNING, logger="django_ox")
-        _, result, _ = self._timed_out(task_timeout=0.2)
+        _, result = self._timed_out()
         (timed_out,) = events(caplog, "task_timed_out")
         assert timed_out.task_id == str(result.id)
-        assert timed_out.timeout_s == 0.2
-        assert timed_out.duration_ms >= 200
+        assert timed_out.timeout_s == self.TIMEOUT
+        assert timed_out.duration_ms >= self.TIMEOUT * 1000
         assert timed_out.levelno == logging.WARNING
         assert events(caplog, "task_retrying")
         assert not events(caplog, "task_stuck")
@@ -624,11 +653,17 @@ class TestSoftTimeout:
         )
 
     def test_a_task_may_catch_it_and_return(self, interruptible_attempts):
-        worker = Worker(task_timeout=0.2, backoff_initial=0, poll_interval=0.05)
-        result = swallow_timeout.enqueue(2.0)
+        worker = Worker(
+            task_timeout=self.TIMEOUT, backoff_initial=0, poll_interval=0.05
+        )
+        result = swallow_timeout.enqueue(self.TASK_SECONDS)
         started = time.monotonic()
         assert worker.run_once()
-        assert time.monotonic() - started < 1.0
+        assert_stopped_at_the_deadline(
+            time.monotonic() - started,
+            timeout=self.TIMEOUT,
+            task_seconds=self.TASK_SECONDS,
+        )
         result.refresh()
         assert result.status == TaskResultStatus.SUCCESSFUL
         assert result.return_value == "cleaned up"
@@ -732,23 +767,40 @@ def row_count(status):
 
 @pytest.mark.django_db(transaction=True)
 class TestDeadline:
+    # The deadline is set when the attempt starts, so what a task reads back
+    # is the timeout, minus however long the worker took to get from the
+    # enqueue to the task body. SLACK is the room for that: a sixth of the
+    # timeout, which is far more than the trip costs and far less than the
+    # distance to any other number the worker could have used, so a report
+    # derived from something else still fails.
+    TIMEOUT = 30.0
+    SLACK = TIMEOUT / 6
+
     def test_deadline_and_remaining_inside_a_task(self):
-        worker = Worker(task_timeout=30, backoff_initial=0, poll_interval=0.05)
+        worker = Worker(
+            task_timeout=self.TIMEOUT, backoff_initial=0, poll_interval=0.05
+        )
         result = report_deadline.enqueue()
         before = timezone.now()
         assert worker.run_once()
         result.refresh()
         reported = result.return_value
         deadline = datetime.fromisoformat(reported["deadline"])
-        assert 29 < (deadline - before).total_seconds() <= 31
-        assert 29 < reported["remaining"] <= 30
+        # The deadline is a whole timeout past the moment the attempt began,
+        # which is at or after `before`; it can only be late, never early.
+        out = (deadline - before).total_seconds()
+        assert self.TIMEOUT <= out <= self.TIMEOUT + self.SLACK, out
+        # What is left of it when the task looks can only be less.
+        assert self.TIMEOUT - self.SLACK <= reported["remaining"] <= self.TIMEOUT
 
     def test_inside_an_async_task(self):
-        worker = Worker(task_timeout=30, backoff_initial=0, poll_interval=0.05)
+        worker = Worker(
+            task_timeout=self.TIMEOUT, backoff_initial=0, poll_interval=0.05
+        )
         result = async_report_deadline.enqueue()
         assert worker.run_once()
         result.refresh()
-        assert 29 < result.return_value <= 30
+        assert self.TIMEOUT - self.SLACK <= result.return_value <= self.TIMEOUT
 
     def test_none_without_a_timeout_and_outside_a_task(self):
         worker = Worker(backoff_initial=0, poll_interval=0.05)
@@ -774,13 +826,16 @@ class TestReleasesWhatItHeld:
         worker writes the outcome; nothing waits, nothing is reaped.
         """
         caplog.set_level(logging.WARNING, logger="django_ox")
+        timeout, task_seconds = 0.2, 5.0
         worker = Worker(
-            task_timeout=0.2, backoff_initial=60, poll_interval=0.05, lock_timeout=5
+            task_timeout=timeout, backoff_initial=60, poll_interval=0.05, lock_timeout=5
         )
-        result = spin_in_atomic.enqueue(5.0)
+        result = spin_in_atomic.enqueue(task_seconds)
         started = time.monotonic()
         assert worker.run_once()
-        assert time.monotonic() - started < 2.0
+        assert_stopped_at_the_deadline(
+            time.monotonic() - started, timeout=timeout, task_seconds=task_seconds
+        )
         assert task_state.get("writer_locked") is True
 
         db_task = row(result)
@@ -1087,12 +1142,23 @@ class TestReleasesWhatItHeld:
 
 @pytest.mark.django_db(transaction=True)
 class TestAsyncTimeout:
+    # As in TestSoftTimeout: the deadline, and how long the coroutine would
+    # run if nothing cancelled it.
+    TIMEOUT = 0.2
+    TASK_SECONDS = 5.0
+
     def test_coroutine_is_cancelled_and_recorded(self, task_state):
-        worker = Worker(task_timeout=0.2, backoff_initial=60, poll_interval=0.05)
-        result = async_spin.enqueue(5.0)
+        worker = Worker(
+            task_timeout=self.TIMEOUT, backoff_initial=60, poll_interval=0.05
+        )
+        result = async_spin.enqueue(self.TASK_SECONDS)
         started = time.monotonic()
         assert worker.run_once()
-        assert time.monotonic() - started < 1.0
+        assert_stopped_at_the_deadline(
+            time.monotonic() - started,
+            timeout=self.TIMEOUT,
+            task_seconds=self.TASK_SECONDS,
+        )
         assert task_state.get("cancelled") is True
         assert task_state["loop"].is_closed()
 
@@ -1152,6 +1218,11 @@ class TestBackstop:
         set; the stuck thread is not waited for.
         """
         caplog.set_level(logging.INFO, logger="django_ox")
+        # The stuck sleep outlasts the deadline, the grace and the drain of
+        # the other task put together, so a run() that returned before it
+        # ended is a run() that left the sleep behind. Judging that by any
+        # tighter number would be judging the machine.
+        stuck_seconds = 2.5
         worker = Worker(
             task_timeout=0.2,
             task_timeout_grace=0.3,
@@ -1160,7 +1231,7 @@ class TestBackstop:
             concurrency=2,
             lock_timeout=60,
         )
-        stuck = slow.enqueue(2.5)
+        stuck = slow.enqueue(stuck_seconds)
         OxTask.objects.filter(id=stuck.id).update(max_attempts=1)
         other = spin.using(queue_name="emails").enqueue(1.0)
         worker.timeouts.by_queue["emails"] = None
@@ -1173,7 +1244,7 @@ class TestBackstop:
         assert not thread.is_alive(), "run() did not return"
         assert worker.recycling
         # It returned before the stuck sleep ended: the drain skipped it.
-        assert returned_after < 2.3, returned_after
+        assert returned_after < stuck_seconds, returned_after
 
         db_task = row(stuck)
         assert db_task.status == OxTask.Status.FAILED
@@ -1199,7 +1270,7 @@ class TestBackstop:
         assert events(caplog, "worker_stopped")
 
         # The thread finishes its sleep, tries to write, and is refused.
-        assert wait_for(lambda: not worker_threads(), timeout=5)
+        assert wait_for(lambda: not worker_threads(), timeout=stuck_seconds * 4)
         # The injection was pending all along and lands as the sleep
         # returns, so what the thread tries to record is its own timeout.
         (lost,) = events(caplog, "task_lease_lost")
@@ -1545,12 +1616,15 @@ class TestUnderATracingTool:
         the timeout is raised inside the task, and nothing is degraded.
         """
         caplog.set_level(logging.WARNING, logger="django_ox")
-        worker = Worker(task_timeout=0.2, backoff_initial=60, poll_interval=0.05)
-        result = spin.enqueue(2.0)
+        timeout, task_seconds = 0.2, 2.0
+        worker = Worker(task_timeout=timeout, backoff_initial=60, poll_interval=0.05)
+        result = spin.enqueue(task_seconds)
         started = time.monotonic()
         assert worker.run_once()
 
-        assert time.monotonic() - started < 1.0
+        assert_stopped_at_the_deadline(
+            time.monotonic() - started, timeout=timeout, task_seconds=task_seconds
+        )
         assert task_state.get("caught") is True
         assert not events(caplog, "timeouts_backstop_only")
         error = row(result).errors[-1]
@@ -1593,14 +1667,17 @@ class TestUnderATracingTool:
         watched or not, and nothing is degraded.
         """
         caplog.set_level(logging.WARNING, logger="django_ox")
-        worker = Worker(task_timeout=0.2, backoff_initial=60, poll_interval=0.05)
-        result = async_spin.enqueue(5.0)
+        timeout, task_seconds = 0.2, 5.0
+        worker = Worker(task_timeout=timeout, backoff_initial=60, poll_interval=0.05)
+        result = async_spin.enqueue(task_seconds)
 
         started = time.monotonic()
         with watching_this_thread():
             assert worker.run_once()
 
-        assert time.monotonic() - started < 2.0
+        assert_stopped_at_the_deadline(
+            time.monotonic() - started, timeout=timeout, task_seconds=task_seconds
+        )
         assert task_state.get("cancelled") is True
         assert row(result).errors[-1]["exception_class_path"] == TIMEOUT_PATH
         assert events(caplog, "task_timed_out")

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -60,8 +60,22 @@ class TestRetries:
         assert db_task.locked_by is None
         assert db_task.locked_at is None
 
-    def test_backoff_doubles_per_attempt(self):
-        worker = Worker(backoff_initial=10, backoff_max=25, poll_interval=0.05)
+    # A retry's delay is written as an absolute run_after, so the delay a
+    # test measures is the rule plus however long the attempt took to get
+    # there. SLACK is the room for that. The cap is set below the second
+    # attempt's doubling, so the two rules give 15 rather than 20, and the
+    # slack is nowhere near wide enough to reach the uncapped value: a cap
+    # that stopped working fails this test rather than passing it.
+    BACKOFF_INITIAL = 10.0
+    BACKOFF_MAX = 15.0
+    SLACK = 4.0
+
+    def test_backoff_doubles_per_attempt_up_to_the_cap(self):
+        worker = Worker(
+            backoff_initial=self.BACKOFF_INITIAL,
+            backoff_max=self.BACKOFF_MAX,
+            poll_interval=0.05,
+        )
         fail_always.enqueue()
 
         delays = []
@@ -73,9 +87,11 @@ class TestRetries:
             db_task.refresh_from_db()
             delays.append((db_task.run_after - before).total_seconds())
 
-        assert 10 <= delays[0] < 11
-        # Second delay is capped at backoff_max, not 20.
-        assert 20 <= delays[1] < 26
+        # The first attempt waits backoff_initial.
+        assert self.BACKOFF_INITIAL <= delays[0] < self.BACKOFF_INITIAL + self.SLACK
+        # The second would double to 20; the cap holds it at backoff_max.
+        assert self.BACKOFF_MAX <= delays[1] < self.BACKOFF_MAX + self.SLACK
+        assert self.BACKOFF_MAX + self.SLACK < self.BACKOFF_INITIAL * 2
 
     def test_retry_until_success(self, worker):
         result = flaky.enqueue(succeed_on=3)
@@ -1096,10 +1112,17 @@ class TestRunLoop:
         assert len(set(closer_threads)) == 2
         assert all(name.startswith("ox") for name in closer_threads)
 
+    # How long each of the two tasks below runs. Both are dispatched into a
+    # pool of two, so they overlap unless the second dispatch is a whole
+    # task behind the first; the length is what buys the room for that, and
+    # a machine slow enough to spend this long between two dispatches has
+    # not run them concurrently in any sense worth passing.
+    CONCURRENT_SECONDS = 1.0
+
     def test_run_loop_processes_tasks_concurrently(self, task_state):
         worker = Worker(concurrency=2, poll_interval=0.05, backoff_initial=0)
-        r1 = record_interval.enqueue(0.4)
-        r2 = record_interval.enqueue(0.4)
+        r1 = record_interval.enqueue(self.CONCURRENT_SECONDS)
+        r2 = record_interval.enqueue(self.CONCURRENT_SECONDS)
 
         thread = self._run_in_thread(worker)
         try:
@@ -1107,7 +1130,7 @@ class TestRunLoop:
                 lambda: (
                     OxTask.objects.filter(status=OxTask.Status.SUCCESSFUL).count() == 2
                 ),
-                timeout=5,
+                timeout=self.CONCURRENT_SECONDS * 10,
             )
         finally:
             worker.request_stop()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2,7 +2,8 @@ import logging
 import threading
 import time
 from contextlib import contextmanager
-from datetime import timedelta
+from datetime import datetime, timedelta
+from typing import NamedTuple
 
 import pytest
 from django.core.exceptions import ImproperlyConfigured
@@ -865,34 +866,108 @@ class TestLeaseRenewalScope:
         assert worker._in_flight == set()
 
 
+class _Hammered(NamedTuple):
+    """What one pass of the reaper over a live worker's task saw."""
+
+    reaped: int
+    # Distinct locked_at values seen before anything was reclaimed: the one
+    # the claim wrote, then one more for every renewal that reached the
+    # database. Two samples with the same value mean nothing landed between
+    # them, so the length is a count of renewals plus the claim.
+    leases: list[datetime]
+    statuses: set[str]
+
+    @property
+    def renewals(self) -> int:
+        return max(len(self.leases) - 1, 0)
+
+
 @pytest.mark.django_db(transaction=True)
 class TestLeaseRenewalUnderTheReaper:
     """
     The point of renewal: the reaper stops reclaiming tasks that are merely
     slow and reclaims only workers that actually stopped reporting.
+
+    The timings below are a ratio rather than a stopwatch. What is under
+    test is the shape the worker documents -- a renewal every
+    LOCK_TIMEOUT / 3, so two consecutive renewals can be missed before the
+    reaper is entitled to conclude anything -- and the ratio, not the
+    absolute value, is what these tests assert. The absolute values are
+    scaled so that a single renewal round-trip on a networked database, or
+    under a coverage tracer, still lands well inside the lease. A tighter
+    lease makes the same test measure how fast the machine is instead.
     """
 
+    LOCK_TIMEOUT = 1.5
+    # What the worker derives from that timeout on its own. The renewal
+    # tests below pass no interval and check this one came out of the
+    # worker, so what is exercised is the rule that ships rather than a
+    # number the test made up.
+    RENEW_INTERVAL = LOCK_TIMEOUT / 3
+    # Longer than the lease, so a claim that stopped being renewed is
+    # certain to age past the timeout inside the window rather than merely
+    # likely to.
+    HAMMER_SECONDS = LOCK_TIMEOUT * 2.25
+    # The task has to still be running when the window closes: a reaper
+    # finds nothing to reclaim on a finished task whatever renewal did, and
+    # a test that let the task finish early would pass on an empty window.
+    TASK_SECONDS = LOCK_TIMEOUT * 3
+
     def _hammer_the_reaper(self, reaper, seconds):
+        """
+        Run the reaper flat out for `seconds`, watching the lease as it goes.
+
+        A count of reclaims on its own cannot tell "renewal held the lease"
+        apart from "there was nothing here to reclaim", so every pass also
+        reads the row: the status it was in, and the lease timestamp, which
+        moves forward once per renewal that reached the database. Sampling
+        stops at the first reclaim, because from there the lease has
+        changed hands and says nothing further about the worker that held
+        it.
+        """
         reaped = 0
+        leases: list[datetime] = []
+        statuses: set[str] = set()
         deadline = time.monotonic() + seconds
         while time.monotonic() < deadline:
+            if reaped == 0:
+                status, locked_at = OxTask.objects.values_list(
+                    "status", "locked_at"
+                ).get()
+                statuses.add(status)
+                if locked_at is not None and locked_at not in leases:
+                    leases.append(locked_at)
             reaped += reaper.reap()
             time.sleep(0.05)
-        return reaped
+        return _Hammered(reaped, leases, statuses)
+
+    def _assert_renewal_held_the_lease(self, hammered):
+        """
+        The claim both renewal tests make: nothing was reclaimed, and the
+        reason was renewal rather than an idle window. A stopped renewal
+        thread fails here even though it reclaims nothing.
+        """
+        assert hammered.reaped == 0
+        assert hammered.statuses == {OxTask.Status.RUNNING}
+        assert hammered.renewals >= 3
+        assert hammered.leases == sorted(hammered.leases)
 
     def test_renewal_keeps_a_slow_task_out_of_the_reaper(self):
         worker = Worker(
-            lock_timeout=0.4, renew_interval=0.1, poll_interval=0.05, backoff_initial=0
+            lock_timeout=self.LOCK_TIMEOUT, poll_interval=0.05, backoff_initial=0
         )
-        reaper = Worker(lock_timeout=0.4, poll_interval=0.05)
-        slow.enqueue(1.0)
+        assert worker.renew_interval == self.RENEW_INTERVAL
+        reaper = Worker(lock_timeout=self.LOCK_TIMEOUT, poll_interval=0.05)
+        slow.enqueue(self.TASK_SECONDS)
 
         thread = start_worker_thread(worker)
         try:
             assert wait_for(
                 lambda: OxTask.objects.get().status == OxTask.Status.RUNNING
             )
-            assert self._hammer_the_reaper(reaper, 0.9) == 0
+            self._assert_renewal_held_the_lease(
+                self._hammer_the_reaper(reaper, self.HAMMER_SECONDS)
+            )
             assert wait_for(
                 lambda: OxTask.objects.get().status == OxTask.Status.SUCCESSFUL
             )
@@ -911,21 +986,26 @@ class TestLeaseRenewalUnderTheReaper:
         its own lock.
         """
         worker = Worker(
-            lock_timeout=0.4,
+            lock_timeout=self.LOCK_TIMEOUT,
             renew_interval=1000,
             reap_interval=1000,
             poll_interval=0.05,
             backoff_initial=0,
         )
-        reaper = Worker(lock_timeout=0.4, poll_interval=0.05)
-        slow.enqueue(1.0)
+        reaper = Worker(lock_timeout=self.LOCK_TIMEOUT, poll_interval=0.05)
+        slow.enqueue(self.TASK_SECONDS)
 
         thread = start_worker_thread(worker)
         try:
             assert wait_for(
                 lambda: OxTask.objects.get().status == OxTask.Status.RUNNING
             )
-            assert self._hammer_the_reaper(reaper, 0.9) >= 1
+            hammered = self._hammer_the_reaper(reaper, self.HAMMER_SECONDS)
+            assert hammered.reaped >= 1
+            # Reclaimed for the stated reason: the task was running the
+            # whole time and its lease sat at the value the claim wrote.
+            assert hammered.statuses == {OxTask.Status.RUNNING}
+            assert hammered.renewals == 0
         finally:
             worker.request_stop()
             thread.join(timeout=5)
@@ -938,10 +1018,11 @@ class TestLeaseRenewalUnderTheReaper:
         the poll loop.
         """
         worker = Worker(
-            lock_timeout=0.4, renew_interval=0.1, poll_interval=0.05, backoff_initial=0
+            lock_timeout=self.LOCK_TIMEOUT, poll_interval=0.05, backoff_initial=0
         )
-        reaper = Worker(lock_timeout=0.4, poll_interval=0.05)
-        slow.enqueue(1.0)
+        assert worker.renew_interval == self.RENEW_INTERVAL
+        reaper = Worker(lock_timeout=self.LOCK_TIMEOUT, poll_interval=0.05)
+        slow.enqueue(self.TASK_SECONDS)
 
         thread = start_worker_thread(worker)
         try:
@@ -949,7 +1030,9 @@ class TestLeaseRenewalUnderTheReaper:
                 lambda: OxTask.objects.get().status == OxTask.Status.RUNNING
             )
             worker.request_stop()  # drain begins with the task still running
-            assert self._hammer_the_reaper(reaper, 0.9) == 0
+            self._assert_renewal_held_the_lease(
+                self._hammer_the_reaper(reaper, self.HAMMER_SECONDS)
+            )
             thread.join(timeout=5)
             assert not thread.is_alive()
         finally:


### PR DESCRIPTION
### Changed

- A worker enforces `TASK_TIMEOUT` on a sync task through the grace backstop
  alone while a coverage tool or a debugger is watching the thread the
  attempt runs on. Two things count: a trace function (`sys.settrace`, which
  `coverage run` installs before Python 3.14, and which `pdb` and most
  debuggers install), and a registered `sys.monitoring` tool with events
  enabled (which `coverage run` uses from Python 3.14 on). Nothing is raised
  inside the task. A task that returns within `TASK_TIMEOUT` plus
  `TASK_TIMEOUT_GRACE` is recorded as whatever it did, however long it ran,
  with no `task_timed_out` event; one still running then is recorded as
  failed and recycles the worker. An async task is cancelled at its deadline
  either way, and a profile hook (`sys.setprofile`) is not consulted.
- The worker logs `timeouts_backstop_only` once under such a tool, on the
  first attempt it registers rather than at startup. That event now carries
  `reason` (`interpreter` or `tracing_tool`) and, for a tool, `tracer`:
  `sys.settrace`, or `sys.monitoring (NAME)`.