### PR TITLE
Refresh Context7 when the documentation changes

### DIFF
--- a/.github/workflows/context7-refresh.yml
+++ b/.github/workflows/context7-refresh.yml
@@ -1,0 +1,62 @@
+name: Refresh Context7
+
+# Context7 serves this package's docs to coding assistants. It re-parses the
+# repository on its own schedule, and for a library this size that threshold is
+# 45 days, and only if the library has been requested recently. Between a docs
+# change and that reparse, assistants are served the old corpus.
+#
+# This workflow closes that window: every docs change on main asks Context7 to
+# re-parse immediately.
+#
+# It does not address exclusions. Files listed in context7.json's excludeFiles
+# and excludeFolders were still being served after a refresh on 2026-08-25, so
+# that is a separate problem and a refresh is not its fix.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "README.md"
+      - "context7.json"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # The refresh reads context7.json from the default branch as it stands on
+      # Context7's side, so there is nothing to check out.
+      - name: Ask Context7 to re-parse the repository
+        env:
+          API_KEY: ${{ secrets.CONTEXT7_API_KEY }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${API_KEY}" ]; then
+            echo "::error::CONTEXT7_API_KEY is not set. Add it under" \
+                 "Settings > Secrets and variables > Actions."
+            exit 1
+          fi
+
+          # curl exits 0 on a 4xx, so the status code is captured and checked
+          # rather than trusted. A silent failure here is worse than a red run:
+          # it looks like the docs are current when they are months stale.
+          status=$(curl -sS -o response.json -w '%{http_code}' \
+            -X POST https://context7.com/api/v1/refresh \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${API_KEY}" \
+            -d '{"libraryName": "/oxpull/django-ox"}')
+
+          echo "HTTP ${status}"
+          cat response.json
+          echo
+
+          if [ "${status}" != "200" ]; then
+            echo "::error::Context7 refresh failed with HTTP ${status}"
+            exit 1
+          fi


### PR DESCRIPTION
## What this does

Context7 serves this package's docs to coding assistants. It re-parses on its own schedule: for a library outside the top 5,000 that is **45 days**, and only if the library has been requested recently ([Keeping Libraries Fresh](https://context7.com/docs/library-updates), fetched 2026-08-25). Between a docs change and that reparse, assistants get the old corpus.

This adds a workflow that posts to the refresh API on any push to `main` touching `docs/`, `README.md` or `context7.json`, following Context7's documented GitHub Actions integration ([docs](https://context7.com/docs/integrations/github-actions), fetched 2026-08-25).

One deviation from their sample: theirs is `curl -s` with no status check. curl exits 0 on a 4xx, so their version fails silently, and a silent failure here looks exactly like fresh documentation. This one checks `%{http_code}`.

## What this does NOT do

It does not fix the fact that `AGENTS.md`, the contributor guide, is the first snippet an assistant receives.

I originally believed a refresh would fix that, because the exclusions in `context7.json` had landed eight minutes after Context7's last parse. **That turned out to be wrong.** A refresh ran on 2026-08-25 and `lastUpdateDate` moved from `13:32:30Z` to `22:31:58Z`, and all three excluded paths were still served afterwards:

| Path | In `context7.json` since | Still served |
| --- | --- | --- |
| `AGENTS.md` | 2026-08-24T13:40Z | 4 snippets |
| `CONTRIBUTING.md` | 2026-08-23T09:51Z | 1 snippet |
| `benchmarks/` | 2026-08-23T09:51Z | 3 snippets |

`CONTRIBUTING.md` and `benchmarks/` were excluded more than a day before **both** parses. So this is not a timing problem. Context7 does not appear to be applying the repo's `context7.json` at all, and a refresh does not change that.

That needs the admin panel at context7.com, not a commit. Tracking separately.

## Before this merges

Add a `CONTEXT7_API_KEY` repository secret under **Settings > Secrets and variables > Actions**. Without it the job fails with a clear message rather than passing quietly.