### PR TITLE
Move both CodeQL steps to v4 in one commit

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -53,11 +53,11 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
-      - uses: github/codeql-action/init@f3712979fa5f215279b101dd0a2e3bdfb4353324  # v3
+      - uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938  # v4.37.9
         with:
           languages: python
           queries: security-extended
-      - uses: github/codeql-action/analyze@f3712979fa5f215279b101dd0a2e3bdfb4353324  # v3
+      - uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938  # v4.37.9
 
   # Note: there is no separate bandit job. The same rule family runs as ruff's
   # `S` selector inside the existing lint job, which is faster and one tool


### PR DESCRIPTION
`github/codeql-action` requires every step in a workflow to run the same version. Dependabot opens one pull request per step, so #24 and #25 each move one of `init` and `analyze` and leave the other behind. Both of those runs failed:

> Not all workflow steps that use `github/codeql-action` actions use the same version.

This moves both pins to `cdf488f595d80d6e07e03d4674febd5ab45fa938` (v4.37.9), the same commit Dependabot targeted, in one commit. The trailing comment on each line now names the release rather than the major, so a future mismatch shows up in the diff.

Closes #24. Closes #25.