### PR TITLE
Measure the published claims on the release that ships

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,27 @@ it (PostgreSQL, MySQL 8+) and an atomic compare-and-set UPDATE elsewhere
 Failed tasks retry with exponential backoff up to a configurable attempt
 limit, keeping the full traceback of every attempt.
 
+## Measured under worker kills
+
+A soak and chaos harness ran 0.3.1 for 21.5 minutes of sustained mixed load
+on PostgreSQL 16: 37,804 tasks, nine minutes of which SIGKILLed a random
+worker every 20 to 45 seconds. Eighteen kills, thirty interrupted
+executions. Every task reached a terminal state, every interrupted
+execution was re-executed inside the documented reclaim bound, and the
+median first-attempt latency under kills stayed within a millisecond of the
+undisturbed baseline.
+
+Execution is at-least-once, so a worker killed between finishing a task and
+recording the outcome leaves that task to run again. One task in that run
+executed twice for exactly that reason, and no task executed twice without
+a kill to account for it.
+
+Thirty-seven assertions ran and all thirty-seven passed. The harness
+design, every assertion and the caveats are in
+[SOAK-2026-09-01.md](https://github.com/oxpull/django-ox/blob/main/benchmarks/SOAK-2026-09-01.md),
+written from
+[the raw data](https://github.com/oxpull/django-ox/blob/main/benchmarks/soak-results-raw-2026-09-01.json).
+
 ## Configuration
 
 Every option has a default; add one when you have a reason to.

--- a/benchmarks/SOAK-2026-09-01.md
+++ b/benchmarks/SOAK-2026-09-01.md
@@ -1,0 +1,133 @@
+# Soak and chaos results, 2026-09-01
+
+django-ox 0.3.1 under sustained mixed load and repeated worker SIGKILLs on
+PostgreSQL 16. The harness is `soak.py` in this directory (methodology in
+its docstring and in [README.md](README.md)); the raw data, including
+every sample, every kill event, and every assertion, is in
+[soak-results-raw-2026-09-01.json](soak-results-raw-2026-09-01.json).
+That file is the source of truth and this document is written from it.
+All scenarios and all assertions are reported. None were discarded.
+
+Exact invocation: `soak.py` with seed 350589 (run started
+2026-09-01T13:13:24Z, finished 2026-09-01T13:35:09Z). A prior `--smoke`
+validation run is in `soak-results-raw-2026-09-01-SMOKE.json`; smoke
+numbers are never quoted.
+
+This run repeats the [2026-08-16 run](SOAK-2026-08-16.md) on the current
+release. That one measured 0.1.0, which predates the lease fencing added
+in 0.2.0, so its numbers describe a worker that no longer ships.
+
+## Environment and parameters
+
+| | |
+| --- | --- |
+| Host | Apple M1 Max, 10 logical CPUs, 64 GB |
+| OS | macOS 26.6.2 |
+| Python | 3.12.13 |
+| Django | 6.0.8 |
+| django-ox | 0.3.1 |
+| psycopg | 3.3.4 |
+| PostgreSQL | 16.14 (Debian), in Docker, port 54329 |
+| Reclaim bound | 37.5 s (`LOCK_TIMEOUT` 25 s plus one reap interval) |
+
+Three producer processes and three worker processes per load scenario, a
+combined target of 10 tasks per second, across a mixed workload of quick,
+medium, slow and deliberately failing task types.
+
+## Scenarios
+
+| Scenario | Load | Kills | Tasks | Terminal states |
+| --- | --- | --- | --- | --- |
+| steady | 720.3 s | 0 | 21,600 | 20,426 SUCCESSFUL, 1,174 FAILED |
+| chaos | 540.5 s | 17 | 16,200 | 15,316 SUCCESSFUL, 884 FAILED |
+| crash-window | 28.2 s | 1 | 4 | 4 SUCCESSFUL |
+
+Every FAILED row in steady and chaos is a `doomed` task, a type written to
+fail on every attempt so that the retry ceiling is exercised. In both
+scenarios the count of doomed tasks equals the count of FAILED rows
+exactly, and there were no unexplained failures.
+
+Total: 37,804 tasks, 18 kills, 21.5 minutes under load.
+
+## Assertions
+
+Thirty-seven assertions ran across the three scenarios. All thirty-seven
+passed. The ones that carry the durability claim:
+
+| Assertion | steady | chaos | crash-window |
+| --- | --- | --- | --- |
+| Every enqueued task has a row | 21,600 of 21,600 | 16,200 of 16,200 | 4 of 4 |
+| All tasks terminal after drain | 0 non-terminal | 0 non-terminal | 0 non-terminal |
+| No lock older than the reclaim bound | 0 over 144 samples | 0 over 109 samples | 0 over 14 samples |
+| Attempts never exceed `MAX_ATTEMPTS` | 0 violations | 0 violations | 0 violations |
+| Attempts equals the worker-id count | 0 violations | 0 violations | 0 violations |
+| Every SUCCESSFUL task has a ledger completion | 0 phantom | 0 phantom | 0 phantom |
+| Interrupted executions resolved | 0 interrupted | 28 of 28 re-executed | 2 of 2 re-executed |
+| Re-execution inside the bound | no reclaims | max 19.5 s | max 19.7 s |
+| Double completions attributable to a kill | none observed | 1, 0 unattributed | none observed |
+| No unexpected worker exits | 0 | 0 | 0 |
+
+## The double execution, in full
+
+One task executed twice in the chaos scenario: `c997a354-a137-4595-8689-fd68ccef53fa`,
+a `quick` task, completed by pid 2607 at 13:27:49.084Z and again by pid
+3086 at 13:28:04.662Z, 15.6 seconds apart. The first worker was SIGKILLed
+after its task body finished and before the outcome was recorded, so the
+reaper found a lease with no observed outcome, returned the task to the
+queue, and a second worker ran it.
+
+**This is the documented behaviour, not a defect.** django-ox executes
+tasks at least once. A worker killed between finishing a task and
+recording it leaves no evidence that the work happened, and the only safe
+reading of that state is to run the task again. A queue that promised
+otherwise on a database would be promising something it cannot deliver
+through a `SIGKILL`.
+
+The property that matters is that a second execution is always
+attributable to a kill. Across 37,804 tasks the harness found zero double
+completions that could not be traced to a worker being killed, and zero
+tasks that ran twice without a kill.
+
+The [2026-08-16 run](SOAK-2026-08-16.md) recorded no double executions at
+all. That was the same guarantee producing a different sample, not a
+stronger one: whether a kill lands inside the window between finishing and
+recording is a matter of timing.
+
+## Latency
+
+First-attempt latency, all task types, seconds:
+
+| Scenario | p50 | p95 | p99 | max |
+| --- | --- | --- | --- | --- |
+| steady | 0.122 | 1.526 | 1.636 | 1.733 |
+| chaos | 0.123 | 1.526 | 1.627 | 1.744 |
+
+Killing a worker every 20 to 45 seconds moved p50 by one millisecond and
+p99 by nine. The queue depth stayed bounded throughout: the largest READY
+backlog observed was 26 rows in steady and 24 under chaos.
+
+The 2026-08-16 run measured p50 0.211 s in steady and 0.217 s under
+chaos on the same host and the same database. The current release is
+faster at the median under both conditions.
+
+## Findings
+
+1. Every one of 37,804 tasks reached a terminal state. Nothing was lost.
+2. All 30 executions interrupted by a kill were re-executed, none were
+   abandoned, and none were left unresolved. The slowest reclaim was
+   19.7 seconds against a documented bound of 37.5.
+3. The one task that executed twice is attributable to a kill, which is
+   what at-least-once execution means. No task executed twice without one.
+4. Retry counts stayed bounded on every row, and the worker-id count
+   matched the attempt count on every row, in every scenario.
+5. Repeated kills did not degrade latency or grow the backlog.
+
+## Caveats
+
+This is one host, one database, and one 21.5-minute run at roughly 10
+tasks per second. It says nothing about a cluster, about other databases,
+or about load an order of magnitude higher. Throughput here is not a
+product claim; the comparison against the other database-backed backend is
+on the [benchmarks page](https://oxpull.com/django-ox/benchmarks/). What
+this run measures is whether the documented durability behaviour holds
+while workers are being killed underneath it.

--- a/benchmarks/soak-results-raw-2026-09-01-SMOKE.json
+++ b/benchmarks/soak-results-raw-2026-09-01-SMOKE.json
@@ -1,0 +1,1538 @@
+{
+  "date": "2026-09-01",
+  "started_at": "2026-09-01T13:10:20+00:00",
+  "invocation": "soak.py --smoke",
+  "seed": 130683,
+  "parameters": {
+    "lock_timeout_s": 15.0,
+    "reap_interval_s": 7.5,
+    "reclaim_bound_s": 37.5,
+    "overdue_after_s": 27.5,
+    "worker_poll_interval_s": 0.2,
+    "sample_interval_s": 5.0,
+    "task_mix": [
+      [
+        "quick",
+        70
+      ],
+      [
+        "medium",
+        15
+      ],
+      [
+        "slow",
+        5
+      ],
+      [
+        "flaky_once",
+        5
+      ],
+      [
+        "doomed",
+        5
+      ]
+    ]
+  },
+  "environment": {
+    "cpu": "Apple M1 Max",
+    "memory_bytes": 68719476736,
+    "logical_cpus": "10",
+    "macos": "26.6.2",
+    "python": "3.12.13",
+    "postgres_server": "16.14 (Debian 16.14-1.pgdg13+1)",
+    "packages": {
+      "Django": "6.0.8",
+      "django-ox": "0.3.1",
+      "psycopg": "3.3.4"
+    }
+  },
+  "scenarios": [
+    {
+      "config": {
+        "name": "steady",
+        "kind": "load",
+        "duration": 30.0,
+        "producers": 2,
+        "rate": 5.0,
+        "workers": 2,
+        "concurrency": 2,
+        "chaos": null,
+        "drain_timeout": 90.0
+      },
+      "seed": 130683,
+      "started_at": "2026-09-01T13:10:20+00:00",
+      "load_seconds": 30.6,
+      "wall_seconds": 37.2,
+      "kills": 0,
+      "drained": true,
+      "producers": [
+        {
+          "returncode": 0,
+          "log": "soak-steady-producer0.log",
+          "enqueued": 150,
+          "by_type": {
+            "quick": 104,
+            "flaky_once": 10,
+            "medium": 23,
+            "doomed": 7,
+            "slow": 6
+          }
+        },
+        {
+          "returncode": 0,
+          "log": "soak-steady-producer1.log",
+          "enqueued": 150,
+          "by_type": {
+            "quick": 104,
+            "medium": 21,
+            "doomed": 8,
+            "slow": 10,
+            "flaky_once": 7
+          }
+        }
+      ],
+      "events": [
+        {
+          "at": "2026-09-01T13:10:20+00:00",
+          "event": "worker_started",
+          "slot": 0,
+          "gen": 1,
+          "pid": 95609
+        },
+        {
+          "at": "2026-09-01T13:10:20+00:00",
+          "event": "worker_started",
+          "slot": 1,
+          "gen": 1,
+          "pid": 95610
+        },
+        {
+          "at": "2026-09-01T13:10:57+00:00",
+          "event": "worker_stopping",
+          "slot": 0,
+          "gen": 1,
+          "pid": 95609
+        },
+        {
+          "at": "2026-09-01T13:10:57+00:00",
+          "event": "worker_stopping",
+          "slot": 1,
+          "gen": 1,
+          "pid": 95610
+        }
+      ],
+      "rss": [
+        {
+          "slot": 0,
+          "gen": 1,
+          "samples": 9,
+          "first_kb": 13536,
+          "last_kb": 58272,
+          "max_kb": 58272,
+          "first_at_s": 0.0,
+          "last_at_s": 37.0
+        },
+        {
+          "slot": 1,
+          "gen": 1,
+          "samples": 9,
+          "first_kb": 12816,
+          "last_kb": 58304,
+          "max_kb": 58304,
+          "first_at_s": 0.0,
+          "last_at_s": 37.0
+        }
+      ],
+      "samples": [
+        {
+          "t": "2026-09-01T13:10:20+00:00",
+          "elapsed_s": 0.0,
+          "READY": 0,
+          "RUNNING": 0,
+          "SUCCESSFUL": 0,
+          "FAILED": 0,
+          "overdue_running": 0,
+          "ledger_rows": 0,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 95609,
+              "rss_kb": 13536
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 95610,
+              "rss_kb": 12816
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:10:25+00:00",
+          "elapsed_s": 5.1,
+          "READY": 5,
+          "SUCCESSFUL": 45,
+          "RUNNING": 0,
+          "FAILED": 0,
+          "overdue_running": 0,
+          "ledger_rows": 102,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 95609,
+              "rss_kb": 58032
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 95610,
+              "rss_kb": 57856
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:10:30+00:00",
+          "elapsed_s": 10.2,
+          "READY": 5,
+          "FAILED": 3,
+          "RUNNING": 3,
+          "SUCCESSFUL": 91,
+          "overdue_running": 0,
+          "ledger_rows": 219,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 95609,
+              "rss_kb": 58128
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 95610,
+              "rss_kb": 57920
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:10:35+00:00",
+          "elapsed_s": 15.3,
+          "READY": 3,
+          "FAILED": 5,
+          "RUNNING": 3,
+          "SUCCESSFUL": 141,
+          "overdue_running": 0,
+          "ledger_rows": 338,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 95609,
+              "rss_kb": 58208
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 95610,
+              "rss_kb": 58032
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:10:40+00:00",
+          "elapsed_s": 20.4,
+          "READY": 6,
+          "FAILED": 7,
+          "SUCCESSFUL": 191,
+          "RUNNING": 0,
+          "overdue_running": 0,
+          "ledger_rows": 460,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 95609,
+              "rss_kb": 58224
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 95610,
+              "rss_kb": 58080
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:10:45+00:00",
+          "elapsed_s": 25.5,
+          "RUNNING": 2,
+          "READY": 4,
+          "FAILED": 10,
+          "SUCCESSFUL": 238,
+          "overdue_running": 0,
+          "ledger_rows": 576,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 95609,
+              "rss_kb": 58240
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 95610,
+              "rss_kb": 58224
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:10:50+00:00",
+          "elapsed_s": 30.6,
+          "READY": 3,
+          "FAILED": 13,
+          "SUCCESSFUL": 284,
+          "RUNNING": 0,
+          "overdue_running": 0,
+          "ledger_rows": 686,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 95609,
+              "rss_kb": 58272
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 95610,
+              "rss_kb": 58272
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:10:56+00:00",
+          "elapsed_s": 35.9,
+          "READY": 1,
+          "FAILED": 14,
+          "SUCCESSFUL": 285,
+          "RUNNING": 0,
+          "overdue_running": 0,
+          "ledger_rows": 692,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 95609,
+              "rss_kb": 58272
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 95610,
+              "rss_kb": 58304
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:10:57+00:00",
+          "elapsed_s": 37.0,
+          "FAILED": 15,
+          "SUCCESSFUL": 285,
+          "READY": 0,
+          "RUNNING": 0,
+          "overdue_running": 0,
+          "ledger_rows": 694,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 95609,
+              "rss_kb": 58272
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 95610,
+              "rss_kb": 58304
+            }
+          ]
+        }
+      ],
+      "analysis": {
+        "status_counts": {
+          "SUCCESSFUL": 285,
+          "FAILED": 15
+        },
+        "per_type": {
+          "doomed": {
+            "FAILED": 15
+          },
+          "flaky_once": {
+            "SUCCESSFUL": 17
+          },
+          "medium": {
+            "SUCCESSFUL": 44
+          },
+          "quick": {
+            "SUCCESSFUL": 208
+          },
+          "slow": {
+            "SUCCESSFUL": 16
+          }
+        },
+        "enqueued_by_producers": 300,
+        "task_rows": 300,
+        "executions": 347,
+        "ledger_rows": 694,
+        "completions_histogram": {
+          "1": 285
+        },
+        "double_completed": [],
+        "interrupted_executions": 0,
+        "reclaim_delays_s": [],
+        "reclaim_bound_s": 37.5,
+        "claim_window_missing_starts": 0,
+        "max_overdue_running": 0,
+        "max_ready_backlog": 6,
+        "latency_first_attempt": {
+          "all": {
+            "count": 268,
+            "p50_s": 0.166,
+            "p95_s": 1.55,
+            "p99_s": 1.663,
+            "max_s": 1.706
+          },
+          "medium": {
+            "count": 44,
+            "p50_s": 0.332,
+            "p95_s": 0.456,
+            "p99_s": 0.568,
+            "max_s": 0.568
+          },
+          "quick": {
+            "count": 208,
+            "p50_s": 0.137,
+            "p95_s": 0.262,
+            "p99_s": 0.34,
+            "max_s": 0.444
+          },
+          "slow": {
+            "count": 16,
+            "p50_s": 1.606,
+            "p95_s": 1.706,
+            "p99_s": 1.706,
+            "max_s": 1.706
+          }
+        },
+        "assertions": [
+          {
+            "assertion": "every enqueued task has a row",
+            "passed": true,
+            "observed": "producers reported 300, table has 300"
+          },
+          {
+            "assertion": "all tasks terminal after drain",
+            "passed": true,
+            "observed": "drained=True, non-terminal rows=0"
+          },
+          {
+            "assertion": "no lock older than 27.5s in any live sample",
+            "passed": true,
+            "observed": "max overdue RUNNING rows across 9 samples: 0"
+          },
+          {
+            "assertion": "attempts never exceed max_attempts",
+            "passed": true,
+            "observed": "violations: 0"
+          },
+          {
+            "assertion": "attempts == len(worker_ids) on every row",
+            "passed": true,
+            "observed": "violations: 0"
+          },
+          {
+            "assertion": "every SUCCESSFUL task has >= 1 ledger completion",
+            "passed": true,
+            "observed": "phantom successes: 0"
+          },
+          {
+            "assertion": "exactly-once completions without chaos",
+            "passed": true,
+            "observed": "double-completed tasks: 0"
+          },
+          {
+            "assertion": "interrupted executions re-executed or abandoned",
+            "passed": true,
+            "observed": "interrupted: 0, re-executed: 0, abandoned: 0, unresolved: 0"
+          },
+          {
+            "assertion": "re-execution within 37.5s of interrupted start",
+            "passed": true,
+            "observed": "no interrupted executions were re-executed"
+          },
+          {
+            "assertion": "all doomed tasks FAILED with attempts == max_attempts",
+            "passed": true,
+            "observed": "doomed: 15, failed: 15"
+          },
+          {
+            "assertion": "no organic failures outside doomed",
+            "passed": true,
+            "observed": "unexplained FAILED rows: 0, flaky_once FAILED (chaos-consumed attempts): 0"
+          },
+          {
+            "assertion": "no unexpected worker exits",
+            "passed": true,
+            "observed": "unexpected exits: 0"
+          }
+        ]
+      }
+    },
+    {
+      "config": {
+        "name": "chaos",
+        "kind": "load",
+        "duration": 45.0,
+        "producers": 2,
+        "rate": 5.0,
+        "workers": 2,
+        "concurrency": 2,
+        "chaos": {
+          "min_gap": 8.0,
+          "max_gap": 14.0,
+          "restart_min": 1.0,
+          "restart_max": 3.0
+        },
+        "drain_timeout": 120.0
+      },
+      "seed": 130683,
+      "started_at": "2026-09-01T13:10:57+00:00",
+      "load_seconds": 45.5,
+      "wall_seconds": 60.0,
+      "kills": 4,
+      "drained": true,
+      "producers": [
+        {
+          "returncode": 0,
+          "log": "soak-chaos-producer0.log",
+          "enqueued": 225,
+          "by_type": {
+            "quick": 154,
+            "flaky_once": 14,
+            "medium": 33,
+            "doomed": 14,
+            "slow": 10
+          }
+        },
+        {
+          "returncode": 0,
+          "log": "soak-chaos-producer1.log",
+          "enqueued": 225,
+          "by_type": {
+            "quick": 159,
+            "medium": 34,
+            "doomed": 12,
+            "slow": 12,
+            "flaky_once": 8
+          }
+        }
+      ],
+      "events": [
+        {
+          "at": "2026-09-01T13:10:57+00:00",
+          "event": "worker_started",
+          "slot": 0,
+          "gen": 1,
+          "pid": 95954
+        },
+        {
+          "at": "2026-09-01T13:10:57+00:00",
+          "event": "worker_started",
+          "slot": 1,
+          "gen": 1,
+          "pid": 95955
+        },
+        {
+          "at": "2026-09-01T13:11:06+00:00",
+          "event": "worker_killed",
+          "slot": 0,
+          "gen": 1,
+          "pid": 95954
+        },
+        {
+          "at": "2026-09-01T13:11:09+00:00",
+          "event": "worker_started",
+          "slot": 0,
+          "gen": 2,
+          "pid": 96022
+        },
+        {
+          "at": "2026-09-01T13:11:18+00:00",
+          "event": "worker_killed",
+          "slot": 0,
+          "gen": 2,
+          "pid": 96022
+        },
+        {
+          "at": "2026-09-01T13:11:20+00:00",
+          "event": "worker_started",
+          "slot": 0,
+          "gen": 3,
+          "pid": 96086
+        },
+        {
+          "at": "2026-09-01T13:11:27+00:00",
+          "event": "worker_killed",
+          "slot": 1,
+          "gen": 1,
+          "pid": 95955
+        },
+        {
+          "at": "2026-09-01T13:11:30+00:00",
+          "event": "worker_started",
+          "slot": 1,
+          "gen": 2,
+          "pid": 96135
+        },
+        {
+          "at": "2026-09-01T13:11:39+00:00",
+          "event": "worker_killed",
+          "slot": 1,
+          "gen": 2,
+          "pid": 96135
+        },
+        {
+          "at": "2026-09-01T13:11:41+00:00",
+          "event": "worker_started",
+          "slot": 1,
+          "gen": 3,
+          "pid": 96182
+        },
+        {
+          "at": "2026-09-01T13:11:57+00:00",
+          "event": "worker_stopping",
+          "slot": 0,
+          "gen": 3,
+          "pid": 96086
+        },
+        {
+          "at": "2026-09-01T13:11:57+00:00",
+          "event": "worker_stopping",
+          "slot": 1,
+          "gen": 3,
+          "pid": 96182
+        }
+      ],
+      "rss": [
+        {
+          "slot": 0,
+          "gen": 1,
+          "samples": 2,
+          "first_kb": 13232,
+          "last_kb": 58080,
+          "max_kb": 58080,
+          "first_at_s": 0.0,
+          "last_at_s": 5.1
+        },
+        {
+          "slot": 0,
+          "gen": 2,
+          "samples": 2,
+          "first_kb": 58144,
+          "last_kb": 58224,
+          "max_kb": 58224,
+          "first_at_s": 15.3,
+          "last_at_s": 20.4
+        },
+        {
+          "slot": 0,
+          "gen": 3,
+          "samples": 8,
+          "first_kb": 57856,
+          "last_kb": 58208,
+          "max_kb": 58208,
+          "first_at_s": 25.5,
+          "last_at_s": 59.9
+        },
+        {
+          "slot": 1,
+          "gen": 1,
+          "samples": 6,
+          "first_kb": 13040,
+          "last_kb": 58656,
+          "max_kb": 58656,
+          "first_at_s": 0.0,
+          "last_at_s": 25.5
+        },
+        {
+          "slot": 1,
+          "gen": 2,
+          "samples": 2,
+          "first_kb": 57728,
+          "last_kb": 57856,
+          "max_kb": 57856,
+          "first_at_s": 35.7,
+          "last_at_s": 40.8
+        },
+        {
+          "slot": 1,
+          "gen": 3,
+          "samples": 4,
+          "first_kb": 57584,
+          "last_kb": 57696,
+          "max_kb": 57696,
+          "first_at_s": 46.0,
+          "last_at_s": 59.9
+        }
+      ],
+      "samples": [
+        {
+          "t": "2026-09-01T13:10:57+00:00",
+          "elapsed_s": 0.0,
+          "READY": 0,
+          "RUNNING": 0,
+          "SUCCESSFUL": 0,
+          "FAILED": 0,
+          "overdue_running": 0,
+          "ledger_rows": 0,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 95954,
+              "rss_kb": 13232
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 95955,
+              "rss_kb": 13040
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:11:02+00:00",
+          "elapsed_s": 5.1,
+          "READY": 3,
+          "RUNNING": 2,
+          "SUCCESSFUL": 45,
+          "FAILED": 0,
+          "overdue_running": 0,
+          "ledger_rows": 104,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 95954,
+              "rss_kb": 58080
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 95955,
+              "rss_kb": 58432
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:11:07+00:00",
+          "elapsed_s": 10.2,
+          "READY": 6,
+          "FAILED": 3,
+          "RUNNING": 3,
+          "SUCCESSFUL": 90,
+          "overdue_running": 0,
+          "ledger_rows": 219,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 95955,
+              "rss_kb": 58496
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:11:12+00:00",
+          "elapsed_s": 15.3,
+          "READY": 3,
+          "FAILED": 5,
+          "RUNNING": 1,
+          "SUCCESSFUL": 143,
+          "overdue_running": 0,
+          "ledger_rows": 343,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 95955,
+              "rss_kb": 58560
+            },
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 96022,
+              "rss_kb": 58144
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:11:17+00:00",
+          "elapsed_s": 20.4,
+          "FAILED": 7,
+          "READY": 6,
+          "RUNNING": 1,
+          "SUCCESSFUL": 190,
+          "overdue_running": 0,
+          "ledger_rows": 459,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 95955,
+              "rss_kb": 58624
+            },
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 96022,
+              "rss_kb": 58224
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:11:22+00:00",
+          "elapsed_s": 25.5,
+          "RUNNING": 3,
+          "FAILED": 10,
+          "SUCCESSFUL": 236,
+          "READY": 5,
+          "overdue_running": 0,
+          "ledger_rows": 573,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 95955,
+              "rss_kb": 58656
+            },
+            {
+              "slot": 0,
+              "gen": 3,
+              "pid": 96086,
+              "rss_kb": 57856
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:11:27+00:00",
+          "elapsed_s": 30.6,
+          "RUNNING": 3,
+          "FAILED": 13,
+          "SUCCESSFUL": 287,
+          "READY": 3,
+          "overdue_running": 0,
+          "ledger_rows": 696,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 3,
+              "pid": 96086,
+              "rss_kb": 58000
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:11:33+00:00",
+          "elapsed_s": 35.7,
+          "RUNNING": 3,
+          "FAILED": 14,
+          "SUCCESSFUL": 337,
+          "READY": 2,
+          "overdue_running": 0,
+          "ledger_rows": 802,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 3,
+              "pid": 96086,
+              "rss_kb": 58048
+            },
+            {
+              "slot": 1,
+              "gen": 2,
+              "pid": 96135,
+              "rss_kb": 57728
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:11:38+00:00",
+          "elapsed_s": 40.8,
+          "RUNNING": 3,
+          "FAILED": 15,
+          "SUCCESSFUL": 382,
+          "READY": 8,
+          "overdue_running": 0,
+          "ledger_rows": 922,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 3,
+              "pid": 96086,
+              "rss_kb": 58128
+            },
+            {
+              "slot": 1,
+              "gen": 2,
+              "pid": 96135,
+              "rss_kb": 57856
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:11:43+00:00",
+          "elapsed_s": 46.0,
+          "RUNNING": 1,
+          "FAILED": 19,
+          "SUCCESSFUL": 423,
+          "READY": 7,
+          "overdue_running": 0,
+          "ledger_rows": 1033,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 3,
+              "pid": 96086,
+              "rss_kb": 58176
+            },
+            {
+              "slot": 1,
+              "gen": 3,
+              "pid": 96182,
+              "rss_kb": 57584
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:11:48+00:00",
+          "elapsed_s": 51.3,
+          "RUNNING": 1,
+          "FAILED": 26,
+          "SUCCESSFUL": 423,
+          "READY": 0,
+          "overdue_running": 0,
+          "ledger_rows": 1049,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 3,
+              "pid": 96086,
+              "rss_kb": 58192
+            },
+            {
+              "slot": 1,
+              "gen": 3,
+              "pid": 96182,
+              "rss_kb": 57664
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:11:53+00:00",
+          "elapsed_s": 56.6,
+          "RUNNING": 1,
+          "FAILED": 26,
+          "SUCCESSFUL": 423,
+          "READY": 0,
+          "overdue_running": 0,
+          "ledger_rows": 1049,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 3,
+              "pid": 96086,
+              "rss_kb": 58192
+            },
+            {
+              "slot": 1,
+              "gen": 3,
+              "pid": 96182,
+              "rss_kb": 57680
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:11:57+00:00",
+          "elapsed_s": 59.9,
+          "SUCCESSFUL": 424,
+          "FAILED": 26,
+          "READY": 0,
+          "RUNNING": 0,
+          "overdue_running": 0,
+          "ledger_rows": 1051,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 3,
+              "pid": 96086,
+              "rss_kb": 58208
+            },
+            {
+              "slot": 1,
+              "gen": 3,
+              "pid": 96182,
+              "rss_kb": 57696
+            }
+          ]
+        }
+      ],
+      "analysis": {
+        "status_counts": {
+          "SUCCESSFUL": 424,
+          "FAILED": 26
+        },
+        "per_type": {
+          "doomed": {
+            "FAILED": 26
+          },
+          "flaky_once": {
+            "SUCCESSFUL": 22
+          },
+          "medium": {
+            "SUCCESSFUL": 67
+          },
+          "quick": {
+            "SUCCESSFUL": 313
+          },
+          "slow": {
+            "SUCCESSFUL": 22
+          }
+        },
+        "enqueued_by_producers": 450,
+        "task_rows": 450,
+        "executions": 527,
+        "ledger_rows": 1051,
+        "completions_histogram": {
+          "1": 424
+        },
+        "double_completed": [],
+        "interrupted_executions": 3,
+        "reclaim_delays_s": [
+          15.07,
+          17.09,
+          17.63
+        ],
+        "reclaim_bound_s": 37.5,
+        "claim_window_missing_starts": 0,
+        "max_overdue_running": 0,
+        "max_ready_backlog": 8,
+        "latency_first_attempt": {
+          "all": {
+            "count": 399,
+            "p50_s": 0.181,
+            "p95_s": 1.558,
+            "p99_s": 1.702,
+            "max_s": 1.729
+          },
+          "medium": {
+            "count": 66,
+            "p50_s": 0.326,
+            "p95_s": 0.551,
+            "p99_s": 0.785,
+            "max_s": 0.785
+          },
+          "quick": {
+            "count": 312,
+            "p50_s": 0.153,
+            "p95_s": 0.354,
+            "p99_s": 0.58,
+            "max_s": 0.71
+          },
+          "slow": {
+            "count": 21,
+            "p50_s": 1.632,
+            "p95_s": 1.709,
+            "p99_s": 1.729,
+            "max_s": 1.729
+          }
+        },
+        "assertions": [
+          {
+            "assertion": "every enqueued task has a row",
+            "passed": true,
+            "observed": "producers reported 450, table has 450"
+          },
+          {
+            "assertion": "all tasks terminal after drain",
+            "passed": true,
+            "observed": "drained=True, non-terminal rows=0"
+          },
+          {
+            "assertion": "no lock older than 27.5s in any live sample",
+            "passed": true,
+            "observed": "max overdue RUNNING rows across 13 samples: 0"
+          },
+          {
+            "assertion": "attempts never exceed max_attempts",
+            "passed": true,
+            "observed": "violations: 0"
+          },
+          {
+            "assertion": "attempts == len(worker_ids) on every row",
+            "passed": true,
+            "observed": "violations: 0"
+          },
+          {
+            "assertion": "every SUCCESSFUL task has >= 1 ledger completion",
+            "passed": true,
+            "observed": "phantom successes: 0"
+          },
+          {
+            "assertion": "double completions only from killed workers",
+            "passed": true,
+            "observed": "double-completed tasks: 0, unattributed to a kill: 0"
+          },
+          {
+            "assertion": "interrupted executions re-executed or abandoned",
+            "passed": true,
+            "observed": "interrupted: 3, re-executed: 3, abandoned: 0, unresolved: 0"
+          },
+          {
+            "assertion": "re-execution within 37.5s of interrupted start",
+            "passed": true,
+            "observed": "max delay 17.6s over 3 reclaims"
+          },
+          {
+            "assertion": "all doomed tasks FAILED with attempts == max_attempts",
+            "passed": true,
+            "observed": "doomed: 26, failed: 26"
+          },
+          {
+            "assertion": "no organic failures outside doomed",
+            "passed": true,
+            "observed": "unexplained FAILED rows: 0, flaky_once FAILED (chaos-consumed attempts): 0"
+          },
+          {
+            "assertion": "no unexpected worker exits",
+            "passed": true,
+            "observed": "unexpected exits: 0"
+          }
+        ]
+      }
+    },
+    {
+      "config": {
+        "name": "crash-window",
+        "kind": "crash_window",
+        "tasks": 4,
+        "hold_seconds": 5.0,
+        "concurrency": 2,
+        "restart_delay": 3.0,
+        "timeout": 120.0
+      },
+      "seed": 130683,
+      "started_at": "2026-09-01T13:11:57+00:00",
+      "load_seconds": 25.2,
+      "wall_seconds": 25.2,
+      "kills": 1,
+      "drained": true,
+      "running_at_kill": 2,
+      "producers": [
+        {
+          "enqueued": 4,
+          "by_type": {
+            "slow_hold": 4
+          },
+          "returncode": 0
+        }
+      ],
+      "events": [
+        {
+          "at": "2026-09-01T13:11:57+00:00",
+          "event": "worker_started",
+          "slot": 0,
+          "gen": 1,
+          "pid": 96247
+        },
+        {
+          "at": "2026-09-01T13:11:58+00:00",
+          "event": "worker_killed",
+          "slot": 0,
+          "gen": 1,
+          "pid": 96247
+        },
+        {
+          "at": "2026-09-01T13:12:01+00:00",
+          "event": "worker_started",
+          "slot": 0,
+          "gen": 2,
+          "pid": 96269
+        },
+        {
+          "at": "2026-09-01T13:12:22+00:00",
+          "event": "worker_stopping",
+          "slot": 0,
+          "gen": 2,
+          "pid": 96269
+        }
+      ],
+      "rss": [
+        {
+          "slot": 0,
+          "gen": 1,
+          "samples": 1,
+          "first_kb": 57264,
+          "last_kb": 57264,
+          "max_kb": 57264,
+          "first_at_s": 1.0,
+          "last_at_s": 1.0
+        },
+        {
+          "slot": 0,
+          "gen": 2,
+          "samples": 11,
+          "first_kb": 10944,
+          "last_kb": 57584,
+          "max_kb": 57584,
+          "first_at_s": 4.1,
+          "last_at_s": 24.9
+        }
+      ],
+      "samples": [
+        {
+          "t": "2026-09-01T13:11:58+00:00",
+          "elapsed_s": 1.0,
+          "RUNNING": 2,
+          "READY": 2,
+          "SUCCESSFUL": 0,
+          "FAILED": 0,
+          "overdue_running": 0,
+          "ledger_rows": 2,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96247,
+              "rss_kb": 57264
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:12:01+00:00",
+          "elapsed_s": 4.1,
+          "RUNNING": 2,
+          "READY": 2,
+          "SUCCESSFUL": 0,
+          "FAILED": 0,
+          "overdue_running": 0,
+          "ledger_rows": 2,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 96269,
+              "rss_kb": 10944
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:12:03+00:00",
+          "elapsed_s": 6.2,
+          "RUNNING": 4,
+          "READY": 0,
+          "SUCCESSFUL": 0,
+          "FAILED": 0,
+          "overdue_running": 0,
+          "ledger_rows": 4,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 96269,
+              "rss_kb": 57248
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:12:05+00:00",
+          "elapsed_s": 8.3,
+          "RUNNING": 4,
+          "READY": 0,
+          "SUCCESSFUL": 0,
+          "FAILED": 0,
+          "overdue_running": 0,
+          "ledger_rows": 4,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 96269,
+              "rss_kb": 57248
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:12:08+00:00",
+          "elapsed_s": 10.4,
+          "SUCCESSFUL": 2,
+          "RUNNING": 2,
+          "READY": 0,
+          "FAILED": 0,
+          "overdue_running": 0,
+          "ledger_rows": 6,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 96269,
+              "rss_kb": 57424
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:12:10+00:00",
+          "elapsed_s": 12.6,
+          "SUCCESSFUL": 2,
+          "RUNNING": 2,
+          "READY": 0,
+          "FAILED": 0,
+          "overdue_running": 0,
+          "ledger_rows": 6,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 96269,
+              "rss_kb": 57472
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:12:12+00:00",
+          "elapsed_s": 14.7,
+          "SUCCESSFUL": 2,
+          "RUNNING": 2,
+          "READY": 0,
+          "FAILED": 0,
+          "overdue_running": 0,
+          "ledger_rows": 6,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 96269,
+              "rss_kb": 57504
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:12:14+00:00",
+          "elapsed_s": 16.8,
+          "SUCCESSFUL": 2,
+          "RUNNING": 2,
+          "READY": 0,
+          "FAILED": 0,
+          "overdue_running": 0,
+          "ledger_rows": 6,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 96269,
+              "rss_kb": 57536
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:12:16+00:00",
+          "elapsed_s": 19.0,
+          "SUCCESSFUL": 2,
+          "RUNNING": 2,
+          "READY": 0,
+          "FAILED": 0,
+          "overdue_running": 0,
+          "ledger_rows": 6,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 96269,
+              "rss_kb": 57536
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:12:18+00:00",
+          "elapsed_s": 21.1,
+          "SUCCESSFUL": 2,
+          "RUNNING": 2,
+          "READY": 0,
+          "FAILED": 0,
+          "overdue_running": 0,
+          "ledger_rows": 8,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 96269,
+              "rss_kb": 57584
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:12:20+00:00",
+          "elapsed_s": 23.3,
+          "SUCCESSFUL": 2,
+          "RUNNING": 2,
+          "READY": 0,
+          "FAILED": 0,
+          "overdue_running": 0,
+          "ledger_rows": 8,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 96269,
+              "rss_kb": 57584
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:12:22+00:00",
+          "elapsed_s": 24.9,
+          "SUCCESSFUL": 4,
+          "READY": 0,
+          "RUNNING": 0,
+          "FAILED": 0,
+          "overdue_running": 0,
+          "ledger_rows": 10,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 96269,
+              "rss_kb": 57584
+            }
+          ]
+        }
+      ],
+      "analysis": {
+        "status_counts": {
+          "SUCCESSFUL": 4
+        },
+        "per_type": {
+          "slow_hold": {
+            "SUCCESSFUL": 4
+          }
+        },
+        "enqueued_by_producers": 4,
+        "task_rows": 4,
+        "executions": 6,
+        "ledger_rows": 10,
+        "completions_histogram": {
+          "1": 4
+        },
+        "double_completed": [],
+        "interrupted_executions": 2,
+        "reclaim_delays_s": [
+          19.6,
+          19.6
+        ],
+        "reclaim_bound_s": 37.5,
+        "claim_window_missing_starts": 0,
+        "max_overdue_running": 0,
+        "max_ready_backlog": 2,
+        "latency_first_attempt": {
+          "all": {
+            "count": 2,
+            "p50_s": 9.336,
+            "p95_s": 9.336,
+            "p99_s": 9.336,
+            "max_s": 9.336
+          },
+          "slow_hold": {
+            "count": 2,
+            "p50_s": 9.336,
+            "p95_s": 9.336,
+            "p99_s": 9.336,
+            "max_s": 9.336
+          }
+        },
+        "assertions": [
+          {
+            "assertion": "every enqueued task has a row",
+            "passed": true,
+            "observed": "producers reported 4, table has 4"
+          },
+          {
+            "assertion": "all tasks terminal after drain",
+            "passed": true,
+            "observed": "drained=True, non-terminal rows=0"
+          },
+          {
+            "assertion": "no lock older than 27.5s in any live sample",
+            "passed": true,
+            "observed": "max overdue RUNNING rows across 12 samples: 0"
+          },
+          {
+            "assertion": "attempts never exceed max_attempts",
+            "passed": true,
+            "observed": "violations: 0"
+          },
+          {
+            "assertion": "attempts == len(worker_ids) on every row",
+            "passed": true,
+            "observed": "violations: 0"
+          },
+          {
+            "assertion": "every SUCCESSFUL task has >= 1 ledger completion",
+            "passed": true,
+            "observed": "phantom successes: 0"
+          },
+          {
+            "assertion": "double completions only from killed workers",
+            "passed": true,
+            "observed": "double-completed tasks: 0, unattributed to a kill: 0"
+          },
+          {
+            "assertion": "interrupted executions re-executed or abandoned",
+            "passed": true,
+            "observed": "interrupted: 2, re-executed: 2, abandoned: 0, unresolved: 0"
+          },
+          {
+            "assertion": "re-execution within 37.5s of interrupted start",
+            "passed": true,
+            "observed": "max delay 19.6s over 2 reclaims"
+          },
+          {
+            "assertion": "kill interrupted the expected number of in-flight tasks",
+            "passed": true,
+            "observed": "expected 2, observed 2"
+          },
+          {
+            "assertion": "all doomed tasks FAILED with attempts == max_attempts",
+            "passed": true,
+            "observed": "doomed: 0, failed: 0"
+          },
+          {
+            "assertion": "no organic failures outside doomed",
+            "passed": true,
+            "observed": "unexplained FAILED rows: 0, flaky_once FAILED (chaos-consumed attempts): 0"
+          },
+          {
+            "assertion": "no unexpected worker exits",
+            "passed": true,
+            "observed": "unexpected exits: 0"
+          }
+        ]
+      }
+    }
+  ],
+  "total_load_seconds": 101.3,
+  "total_wall_seconds": 122.4,
+  "finished_at": "2026-09-01T13:12:22+00:00"
+}

--- a/benchmarks/soak-results-raw-2026-09-01.json
+++ b/benchmarks/soak-results-raw-2026-09-01.json
@@ -1,0 +1,9001 @@
+{
+  "date": "2026-09-01",
+  "started_at": "2026-09-01T13:13:24+00:00",
+  "invocation": "soak.py",
+  "seed": 350589,
+  "parameters": {
+    "lock_timeout_s": 15.0,
+    "reap_interval_s": 7.5,
+    "reclaim_bound_s": 37.5,
+    "overdue_after_s": 27.5,
+    "worker_poll_interval_s": 0.2,
+    "sample_interval_s": 5.0,
+    "task_mix": [
+      [
+        "quick",
+        70
+      ],
+      [
+        "medium",
+        15
+      ],
+      [
+        "slow",
+        5
+      ],
+      [
+        "flaky_once",
+        5
+      ],
+      [
+        "doomed",
+        5
+      ]
+    ]
+  },
+  "environment": {
+    "cpu": "Apple M1 Max",
+    "memory_bytes": 68719476736,
+    "logical_cpus": "10",
+    "macos": "26.6.2",
+    "python": "3.12.13",
+    "postgres_server": "16.14 (Debian 16.14-1.pgdg13+1)",
+    "packages": {
+      "Django": "6.0.8",
+      "django-ox": "0.3.1",
+      "psycopg": "3.3.4"
+    }
+  },
+  "scenarios": [
+    {
+      "config": {
+        "name": "steady",
+        "kind": "load",
+        "duration": 720.0,
+        "producers": 3,
+        "rate": 10.0,
+        "workers": 3,
+        "concurrency": 4,
+        "chaos": null,
+        "drain_timeout": 240.0
+      },
+      "seed": 350589,
+      "started_at": "2026-09-01T13:13:24+00:00",
+      "load_seconds": 720.3,
+      "wall_seconds": 726.4,
+      "kills": 0,
+      "drained": true,
+      "producers": [
+        {
+          "returncode": 0,
+          "log": "soak-steady-producer0.log",
+          "enqueued": 7200,
+          "by_type": {
+            "quick": 5028,
+            "doomed": 390,
+            "medium": 1076,
+            "slow": 359,
+            "flaky_once": 347
+          }
+        },
+        {
+          "returncode": 0,
+          "log": "soak-steady-producer1.log",
+          "enqueued": 7200,
+          "by_type": {
+            "quick": 4929,
+            "doomed": 410,
+            "medium": 1081,
+            "flaky_once": 393,
+            "slow": 387
+          }
+        },
+        {
+          "returncode": 0,
+          "log": "soak-steady-producer2.log",
+          "enqueued": 7200,
+          "by_type": {
+            "quick": 5033,
+            "flaky_once": 365,
+            "medium": 1035,
+            "doomed": 374,
+            "slow": 393
+          }
+        }
+      ],
+      "events": [
+        {
+          "at": "2026-09-01T13:13:24+00:00",
+          "event": "worker_started",
+          "slot": 0,
+          "gen": 1,
+          "pid": 96867
+        },
+        {
+          "at": "2026-09-01T13:13:24+00:00",
+          "event": "worker_started",
+          "slot": 1,
+          "gen": 1,
+          "pid": 96868
+        },
+        {
+          "at": "2026-09-01T13:13:24+00:00",
+          "event": "worker_started",
+          "slot": 2,
+          "gen": 1,
+          "pid": 96869
+        },
+        {
+          "at": "2026-09-01T13:25:31+00:00",
+          "event": "worker_stopping",
+          "slot": 0,
+          "gen": 1,
+          "pid": 96867
+        },
+        {
+          "at": "2026-09-01T13:25:31+00:00",
+          "event": "worker_stopping",
+          "slot": 1,
+          "gen": 1,
+          "pid": 96868
+        },
+        {
+          "at": "2026-09-01T13:25:31+00:00",
+          "event": "worker_stopping",
+          "slot": 2,
+          "gen": 1,
+          "pid": 96869
+        }
+      ],
+      "rss": [
+        {
+          "slot": 0,
+          "gen": 1,
+          "samples": 144,
+          "first_kb": 14576,
+          "last_kb": 59648,
+          "max_kb": 59648,
+          "first_at_s": 0.0,
+          "last_at_s": 726.3
+        },
+        {
+          "slot": 1,
+          "gen": 1,
+          "samples": 144,
+          "first_kb": 14352,
+          "last_kb": 59360,
+          "max_kb": 59360,
+          "first_at_s": 0.0,
+          "last_at_s": 726.3
+        },
+        {
+          "slot": 2,
+          "gen": 1,
+          "samples": 144,
+          "first_kb": 13520,
+          "last_kb": 59808,
+          "max_kb": 59808,
+          "first_at_s": 0.0,
+          "last_at_s": 726.3
+        }
+      ],
+      "samples": [
+        {
+          "t": "2026-09-01T13:13:24+00:00",
+          "elapsed_s": 0.0,
+          "READY": 0,
+          "RUNNING": 0,
+          "SUCCESSFUL": 0,
+          "FAILED": 0,
+          "overdue_running": 0,
+          "ledger_rows": 0,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 14576
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 14352
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 13520
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:13:29+00:00",
+          "elapsed_s": 5.1,
+          "SUCCESSFUL": 129,
+          "RUNNING": 8,
+          "READY": 10,
+          "FAILED": 0,
+          "overdue_running": 0,
+          "ledger_rows": 301,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 58416
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 58064
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 58544
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:13:34+00:00",
+          "elapsed_s": 10.2,
+          "FAILED": 5,
+          "SUCCESSFUL": 277,
+          "RUNNING": 3,
+          "READY": 18,
+          "overdue_running": 0,
+          "ledger_rows": 645,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 58592
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 58224
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 58704
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:13:40+00:00",
+          "elapsed_s": 15.3,
+          "FAILED": 13,
+          "SUCCESSFUL": 424,
+          "RUNNING": 7,
+          "READY": 12,
+          "overdue_running": 0,
+          "ledger_rows": 996,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 58672
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 58320
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 58784
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:13:45+00:00",
+          "elapsed_s": 20.4,
+          "FAILED": 20,
+          "SUCCESSFUL": 559,
+          "READY": 24,
+          "RUNNING": 6,
+          "overdue_running": 0,
+          "ledger_rows": 1343,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 58736
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 58368
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 58880
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:13:50+00:00",
+          "elapsed_s": 25.5,
+          "FAILED": 29,
+          "SUCCESSFUL": 706,
+          "READY": 24,
+          "RUNNING": 3,
+          "overdue_running": 0,
+          "ledger_rows": 1717,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 58784
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 58432
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 58928
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:13:55+00:00",
+          "elapsed_s": 30.6,
+          "FAILED": 41,
+          "SUCCESSFUL": 859,
+          "READY": 9,
+          "RUNNING": 6,
+          "overdue_running": 0,
+          "ledger_rows": 2090,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 58832
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 58464
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 58992
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:14:00+00:00",
+          "elapsed_s": 35.7,
+          "FAILED": 46,
+          "SUCCESSFUL": 1001,
+          "READY": 15,
+          "RUNNING": 6,
+          "overdue_running": 0,
+          "ledger_rows": 2419,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 58880
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 58528
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59040
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:14:05+00:00",
+          "elapsed_s": 40.8,
+          "FAILED": 54,
+          "RUNNING": 8,
+          "SUCCESSFUL": 1152,
+          "READY": 7,
+          "overdue_running": 0,
+          "ledger_rows": 2784,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 58928
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 58608
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59088
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:14:10+00:00",
+          "elapsed_s": 45.9,
+          "FAILED": 58,
+          "RUNNING": 3,
+          "SUCCESSFUL": 1298,
+          "READY": 15,
+          "overdue_running": 0,
+          "ledger_rows": 3126,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 58960
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 58672
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59136
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:14:15+00:00",
+          "elapsed_s": 51.0,
+          "FAILED": 66,
+          "READY": 19,
+          "RUNNING": 7,
+          "SUCCESSFUL": 1435,
+          "overdue_running": 0,
+          "ledger_rows": 3475,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59008
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 58736
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59168
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:14:20+00:00",
+          "elapsed_s": 56.1,
+          "FAILED": 80,
+          "READY": 6,
+          "RUNNING": 3,
+          "SUCCESSFUL": 1588,
+          "overdue_running": 0,
+          "ledger_rows": 3833,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59072
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 58800
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59232
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:14:25+00:00",
+          "elapsed_s": 61.2,
+          "FAILED": 83,
+          "READY": 15,
+          "RUNNING": 5,
+          "SUCCESSFUL": 1727,
+          "overdue_running": 0,
+          "ledger_rows": 4167,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59136
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 58816
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59280
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:14:30+00:00",
+          "elapsed_s": 66.2,
+          "FAILED": 94,
+          "READY": 11,
+          "RUNNING": 8,
+          "SUCCESSFUL": 1870,
+          "overdue_running": 0,
+          "ledger_rows": 4515,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59168
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 58864
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59312
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:14:36+00:00",
+          "elapsed_s": 71.3,
+          "FAILED": 103,
+          "READY": 17,
+          "RUNNING": 1,
+          "SUCCESSFUL": 2014,
+          "overdue_running": 0,
+          "ledger_rows": 4888,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59184
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 58880
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59360
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:14:41+00:00",
+          "elapsed_s": 76.4,
+          "FAILED": 114,
+          "READY": 10,
+          "RUNNING": 9,
+          "SUCCESSFUL": 2153,
+          "overdue_running": 0,
+          "ledger_rows": 5236,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59216
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 58944
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59392
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:14:46+00:00",
+          "elapsed_s": 81.5,
+          "RUNNING": 1,
+          "FAILED": 122,
+          "SUCCESSFUL": 2304,
+          "READY": 12,
+          "overdue_running": 0,
+          "ledger_rows": 5577,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59248
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 58976
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59456
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:14:51+00:00",
+          "elapsed_s": 86.6,
+          "RUNNING": 7,
+          "FAILED": 127,
+          "SUCCESSFUL": 2444,
+          "READY": 14,
+          "overdue_running": 0,
+          "ledger_rows": 5925,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59280
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 58992
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59472
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:14:56+00:00",
+          "elapsed_s": 91.7,
+          "RUNNING": 6,
+          "FAILED": 139,
+          "SUCCESSFUL": 2587,
+          "READY": 13,
+          "overdue_running": 0,
+          "ledger_rows": 6288,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59280
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59040
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59488
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:15:01+00:00",
+          "elapsed_s": 96.8,
+          "RUNNING": 6,
+          "FAILED": 149,
+          "SUCCESSFUL": 2732,
+          "READY": 11,
+          "overdue_running": 0,
+          "ledger_rows": 6654,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59312
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59056
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59520
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:15:06+00:00",
+          "elapsed_s": 101.8,
+          "RUNNING": 7,
+          "FAILED": 158,
+          "SUCCESSFUL": 2870,
+          "READY": 16,
+          "overdue_running": 0,
+          "ledger_rows": 6999,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59344
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59072
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59520
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:15:11+00:00",
+          "elapsed_s": 106.9,
+          "RUNNING": 2,
+          "FAILED": 170,
+          "SUCCESSFUL": 3012,
+          "READY": 20,
+          "overdue_running": 0,
+          "ledger_rows": 7368,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59344
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59104
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59520
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:15:16+00:00",
+          "elapsed_s": 112.0,
+          "FAILED": 181,
+          "READY": 15,
+          "RUNNING": 4,
+          "SUCCESSFUL": 3157,
+          "overdue_running": 0,
+          "ledger_rows": 7738,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59344
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59104
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59520
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:15:21+00:00",
+          "elapsed_s": 117.1,
+          "FAILED": 189,
+          "READY": 16,
+          "SUCCESSFUL": 3305,
+          "RUNNING": 0,
+          "overdue_running": 0,
+          "ledger_rows": 8086,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59344
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59104
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59552
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:15:27+00:00",
+          "elapsed_s": 122.2,
+          "FAILED": 196,
+          "READY": 18,
+          "RUNNING": 1,
+          "SUCCESSFUL": 3448,
+          "overdue_running": 0,
+          "ledger_rows": 8427,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59136
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59568
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:15:32+00:00",
+          "elapsed_s": 127.3,
+          "FAILED": 199,
+          "READY": 15,
+          "RUNNING": 7,
+          "SUCCESSFUL": 3595,
+          "overdue_running": 0,
+          "ledger_rows": 8783,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59136
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59568
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:15:37+00:00",
+          "elapsed_s": 132.4,
+          "FAILED": 208,
+          "READY": 18,
+          "RUNNING": 5,
+          "SUCCESSFUL": 3737,
+          "overdue_running": 0,
+          "ledger_rows": 9155,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59136
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59600
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:15:42+00:00",
+          "elapsed_s": 137.5,
+          "FAILED": 220,
+          "READY": 12,
+          "RUNNING": 2,
+          "SUCCESSFUL": 3885,
+          "overdue_running": 0,
+          "ledger_rows": 9528,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59392
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59152
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59600
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:15:47+00:00",
+          "elapsed_s": 142.6,
+          "FAILED": 227,
+          "READY": 13,
+          "RUNNING": 5,
+          "SUCCESSFUL": 4027,
+          "overdue_running": 0,
+          "ledger_rows": 9873,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59392
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59152
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59616
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:15:52+00:00",
+          "elapsed_s": 147.7,
+          "FAILED": 233,
+          "READY": 12,
+          "RUNNING": 4,
+          "SUCCESSFUL": 4176,
+          "overdue_running": 0,
+          "ledger_rows": 10222,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59392
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59152
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59632
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:15:57+00:00",
+          "elapsed_s": 152.8,
+          "FAILED": 241,
+          "READY": 17,
+          "RUNNING": 5,
+          "SUCCESSFUL": 4315,
+          "overdue_running": 0,
+          "ledger_rows": 10567,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59408
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59152
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59632
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:16:02+00:00",
+          "elapsed_s": 157.8,
+          "FAILED": 248,
+          "READY": 19,
+          "RUNNING": 7,
+          "SUCCESSFUL": 4457,
+          "overdue_running": 0,
+          "ledger_rows": 10926,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59424
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59152
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59648
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:16:07+00:00",
+          "elapsed_s": 162.9,
+          "FAILED": 259,
+          "READY": 17,
+          "RUNNING": 6,
+          "SUCCESSFUL": 4602,
+          "overdue_running": 0,
+          "ledger_rows": 11286,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59424
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59184
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59648
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:16:12+00:00",
+          "elapsed_s": 168.1,
+          "RUNNING": 6,
+          "FAILED": 268,
+          "SUCCESSFUL": 4749,
+          "READY": 14,
+          "overdue_running": 0,
+          "ledger_rows": 11638,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59424
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59200
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59664
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:16:17+00:00",
+          "elapsed_s": 173.2,
+          "FAILED": 278,
+          "READY": 13,
+          "RUNNING": 4,
+          "SUCCESSFUL": 4895,
+          "overdue_running": 0,
+          "ledger_rows": 11984,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59424
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59200
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59712
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:16:23+00:00",
+          "elapsed_s": 178.2,
+          "FAILED": 282,
+          "READY": 17,
+          "RUNNING": 6,
+          "SUCCESSFUL": 5038,
+          "overdue_running": 0,
+          "ledger_rows": 12354,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59440
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59216
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59712
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:16:28+00:00",
+          "elapsed_s": 183.3,
+          "FAILED": 292,
+          "READY": 14,
+          "RUNNING": 1,
+          "SUCCESSFUL": 5189,
+          "overdue_running": 0,
+          "ledger_rows": 12721,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59440
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59216
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59712
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:16:33+00:00",
+          "elapsed_s": 188.4,
+          "FAILED": 299,
+          "READY": 15,
+          "RUNNING": 3,
+          "SUCCESSFUL": 5332,
+          "overdue_running": 0,
+          "ledger_rows": 13077,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59456
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59232
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59712
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:16:38+00:00",
+          "elapsed_s": 193.5,
+          "FAILED": 306,
+          "READY": 14,
+          "RUNNING": 7,
+          "SUCCESSFUL": 5475,
+          "overdue_running": 0,
+          "ledger_rows": 13434,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59488
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59264
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59712
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:16:43+00:00",
+          "elapsed_s": 198.6,
+          "FAILED": 315,
+          "READY": 12,
+          "RUNNING": 1,
+          "SUCCESSFUL": 5627,
+          "overdue_running": 0,
+          "ledger_rows": 13791,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59488
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59264
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59712
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:16:48+00:00",
+          "elapsed_s": 203.7,
+          "FAILED": 322,
+          "READY": 14,
+          "RUNNING": 6,
+          "SUCCESSFUL": 5766,
+          "overdue_running": 0,
+          "ledger_rows": 14132,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59504
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59264
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59712
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:16:53+00:00",
+          "elapsed_s": 208.8,
+          "FAILED": 331,
+          "READY": 16,
+          "RUNNING": 5,
+          "SUCCESSFUL": 5909,
+          "overdue_running": 0,
+          "ledger_rows": 14496,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59504
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59264
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59712
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:16:58+00:00",
+          "elapsed_s": 213.9,
+          "FAILED": 339,
+          "READY": 11,
+          "RUNNING": 3,
+          "SUCCESSFUL": 6059,
+          "overdue_running": 0,
+          "ledger_rows": 14853,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59504
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59264
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59712
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:17:03+00:00",
+          "elapsed_s": 219.0,
+          "FAILED": 345,
+          "READY": 15,
+          "RUNNING": 4,
+          "SUCCESSFUL": 6200,
+          "overdue_running": 0,
+          "ledger_rows": 15202,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59504
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59264
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59712
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:17:08+00:00",
+          "elapsed_s": 224.1,
+          "FAILED": 356,
+          "READY": 11,
+          "RUNNING": 7,
+          "SUCCESSFUL": 6343,
+          "overdue_running": 0,
+          "ledger_rows": 15553,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59504
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59264
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59712
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:17:13+00:00",
+          "elapsed_s": 229.1,
+          "FAILED": 365,
+          "READY": 13,
+          "RUNNING": 1,
+          "SUCCESSFUL": 6491,
+          "overdue_running": 0,
+          "ledger_rows": 15895,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59504
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59264
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59728
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:17:19+00:00",
+          "elapsed_s": 234.2,
+          "FAILED": 371,
+          "READY": 17,
+          "RUNNING": 1,
+          "SUCCESSFUL": 6634,
+          "overdue_running": 0,
+          "ledger_rows": 16227,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59520
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59264
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59760
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:17:24+00:00",
+          "elapsed_s": 239.4,
+          "FAILED": 380,
+          "READY": 8,
+          "RUNNING": 5,
+          "SUCCESSFUL": 6783,
+          "overdue_running": 0,
+          "ledger_rows": 16580,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59520
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59280
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59760
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:17:29+00:00",
+          "elapsed_s": 244.5,
+          "FAILED": 385,
+          "READY": 11,
+          "RUNNING": 4,
+          "SUCCESSFUL": 6929,
+          "overdue_running": 0,
+          "ledger_rows": 16925,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59536
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59280
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59760
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:17:34+00:00",
+          "elapsed_s": 249.6,
+          "FAILED": 393,
+          "READY": 19,
+          "RUNNING": 6,
+          "SUCCESSFUL": 7064,
+          "overdue_running": 0,
+          "ledger_rows": 17280,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59536
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59296
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59760
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:17:39+00:00",
+          "elapsed_s": 254.6,
+          "FAILED": 406,
+          "READY": 17,
+          "RUNNING": 8,
+          "SUCCESSFUL": 7204,
+          "overdue_running": 0,
+          "ledger_rows": 17640,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59536
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59296
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59760
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:17:44+00:00",
+          "elapsed_s": 259.7,
+          "FAILED": 416,
+          "READY": 12,
+          "RUNNING": 5,
+          "SUCCESSFUL": 7355,
+          "overdue_running": 0,
+          "ledger_rows": 18009,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59536
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59296
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:17:49+00:00",
+          "elapsed_s": 264.8,
+          "FAILED": 421,
+          "READY": 24,
+          "RUNNING": 2,
+          "SUCCESSFUL": 7494,
+          "overdue_running": 0,
+          "ledger_rows": 18372,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59536
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59296
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:17:54+00:00",
+          "elapsed_s": 269.9,
+          "FAILED": 436,
+          "READY": 15,
+          "RUNNING": 7,
+          "SUCCESSFUL": 7636,
+          "overdue_running": 0,
+          "ledger_rows": 18745,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59536
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59296
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:17:59+00:00",
+          "elapsed_s": 275.0,
+          "FAILED": 446,
+          "READY": 13,
+          "RUNNING": 5,
+          "SUCCESSFUL": 7783,
+          "overdue_running": 0,
+          "ledger_rows": 19102,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59552
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59296
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:18:04+00:00",
+          "elapsed_s": 280.1,
+          "FAILED": 452,
+          "READY": 15,
+          "RUNNING": 4,
+          "SUCCESSFUL": 7929,
+          "overdue_running": 0,
+          "ledger_rows": 19450,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59552
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59296
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:18:10+00:00",
+          "elapsed_s": 285.2,
+          "FAILED": 459,
+          "READY": 24,
+          "RUNNING": 3,
+          "SUCCESSFUL": 8067,
+          "overdue_running": 0,
+          "ledger_rows": 19797,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59552
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59312
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:18:15+00:00",
+          "elapsed_s": 290.3,
+          "FAILED": 469,
+          "READY": 16,
+          "RUNNING": 4,
+          "SUCCESSFUL": 8217,
+          "overdue_running": 0,
+          "ledger_rows": 20178,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59552
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59328
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:18:20+00:00",
+          "elapsed_s": 295.4,
+          "FAILED": 481,
+          "READY": 8,
+          "RUNNING": 1,
+          "SUCCESSFUL": 8369,
+          "overdue_running": 0,
+          "ledger_rows": 20531,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59552
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59328
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:18:25+00:00",
+          "elapsed_s": 300.6,
+          "FAILED": 483,
+          "READY": 12,
+          "RUNNING": 4,
+          "SUCCESSFUL": 8513,
+          "overdue_running": 0,
+          "ledger_rows": 20870,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59552
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59328
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:18:30+00:00",
+          "elapsed_s": 305.6,
+          "FAILED": 488,
+          "READY": 13,
+          "RUNNING": 7,
+          "SUCCESSFUL": 8657,
+          "overdue_running": 0,
+          "ledger_rows": 21216,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59552
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59328
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:18:35+00:00",
+          "elapsed_s": 310.7,
+          "FAILED": 497,
+          "READY": 13,
+          "RUNNING": 9,
+          "SUCCESSFUL": 8799,
+          "overdue_running": 0,
+          "ledger_rows": 21562,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59552
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:18:40+00:00",
+          "elapsed_s": 315.8,
+          "FAILED": 505,
+          "READY": 9,
+          "RUNNING": 7,
+          "SUCCESSFUL": 8947,
+          "overdue_running": 0,
+          "ledger_rows": 21916,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59552
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:18:45+00:00",
+          "elapsed_s": 320.9,
+          "FAILED": 511,
+          "READY": 19,
+          "RUNNING": 5,
+          "SUCCESSFUL": 9086,
+          "overdue_running": 0,
+          "ledger_rows": 22266,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59552
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:18:50+00:00",
+          "elapsed_s": 326.0,
+          "FAILED": 520,
+          "READY": 10,
+          "RUNNING": 5,
+          "SUCCESSFUL": 9239,
+          "overdue_running": 0,
+          "ledger_rows": 22628,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59552
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:18:55+00:00",
+          "elapsed_s": 331.1,
+          "FAILED": 526,
+          "READY": 16,
+          "RUNNING": 6,
+          "SUCCESSFUL": 9379,
+          "overdue_running": 0,
+          "ledger_rows": 22978,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59552
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:19:00+00:00",
+          "elapsed_s": 336.2,
+          "FAILED": 536,
+          "READY": 6,
+          "RUNNING": 7,
+          "SUCCESSFUL": 9531,
+          "overdue_running": 0,
+          "ledger_rows": 23339,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59552
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:19:06+00:00",
+          "elapsed_s": 341.3,
+          "FAILED": 541,
+          "READY": 11,
+          "RUNNING": 3,
+          "SUCCESSFUL": 9678,
+          "overdue_running": 0,
+          "ledger_rows": 23677,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59552
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:19:11+00:00",
+          "elapsed_s": 346.4,
+          "FAILED": 547,
+          "READY": 13,
+          "RUNNING": 5,
+          "SUCCESSFUL": 9821,
+          "overdue_running": 0,
+          "ledger_rows": 24023,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59552
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:19:16+00:00",
+          "elapsed_s": 351.5,
+          "FAILED": 555,
+          "READY": 16,
+          "RUNNING": 6,
+          "SUCCESSFUL": 9962,
+          "overdue_running": 0,
+          "ledger_rows": 24382,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59552
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:19:21+00:00",
+          "elapsed_s": 356.6,
+          "FAILED": 565,
+          "READY": 16,
+          "RUNNING": 6,
+          "SUCCESSFUL": 10105,
+          "overdue_running": 0,
+          "ledger_rows": 24730,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59552
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:19:26+00:00",
+          "elapsed_s": 361.7,
+          "FAILED": 573,
+          "READY": 18,
+          "RUNNING": 4,
+          "SUCCESSFUL": 10250,
+          "overdue_running": 0,
+          "ledger_rows": 25098,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59552
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:19:31+00:00",
+          "elapsed_s": 366.8,
+          "FAILED": 582,
+          "READY": 19,
+          "RUNNING": 2,
+          "SUCCESSFUL": 10395,
+          "overdue_running": 0,
+          "ledger_rows": 25466,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59552
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:19:36+00:00",
+          "elapsed_s": 371.9,
+          "FAILED": 593,
+          "READY": 15,
+          "RUNNING": 7,
+          "SUCCESSFUL": 10536,
+          "overdue_running": 0,
+          "ledger_rows": 25832,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59552
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:19:41+00:00",
+          "elapsed_s": 377.0,
+          "FAILED": 607,
+          "READY": 10,
+          "RUNNING": 2,
+          "SUCCESSFUL": 10685,
+          "overdue_running": 0,
+          "ledger_rows": 26212,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59584
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:19:46+00:00",
+          "elapsed_s": 382.1,
+          "FAILED": 612,
+          "READY": 14,
+          "RUNNING": 6,
+          "SUCCESSFUL": 10828,
+          "overdue_running": 0,
+          "ledger_rows": 26547,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59584
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:19:52+00:00",
+          "elapsed_s": 387.3,
+          "FAILED": 617,
+          "READY": 12,
+          "RUNNING": 4,
+          "SUCCESSFUL": 10980,
+          "overdue_running": 0,
+          "ledger_rows": 26911,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59584
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:19:57+00:00",
+          "elapsed_s": 392.4,
+          "FAILED": 626,
+          "READY": 26,
+          "RUNNING": 2,
+          "SUCCESSFUL": 11114,
+          "overdue_running": 0,
+          "ledger_rows": 27266,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59584
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:20:02+00:00",
+          "elapsed_s": 397.5,
+          "FAILED": 639,
+          "READY": 15,
+          "RUNNING": 4,
+          "SUCCESSFUL": 11264,
+          "overdue_running": 0,
+          "ledger_rows": 27644,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59584
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:20:07+00:00",
+          "elapsed_s": 402.6,
+          "FAILED": 645,
+          "READY": 11,
+          "RUNNING": 8,
+          "SUCCESSFUL": 11411,
+          "overdue_running": 0,
+          "ledger_rows": 27999,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59584
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:20:12+00:00",
+          "elapsed_s": 407.7,
+          "FAILED": 651,
+          "READY": 11,
+          "RUNNING": 6,
+          "SUCCESSFUL": 11560,
+          "overdue_running": 0,
+          "ledger_rows": 28344,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59584
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:20:17+00:00",
+          "elapsed_s": 412.8,
+          "FAILED": 658,
+          "READY": 20,
+          "RUNNING": 5,
+          "SUCCESSFUL": 11698,
+          "overdue_running": 0,
+          "ledger_rows": 28686,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59584
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:20:22+00:00",
+          "elapsed_s": 417.9,
+          "FAILED": 670,
+          "READY": 14,
+          "RUNNING": 2,
+          "SUCCESSFUL": 11848,
+          "overdue_running": 0,
+          "ledger_rows": 29054,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59584
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:20:27+00:00",
+          "elapsed_s": 423.0,
+          "FAILED": 676,
+          "READY": 23,
+          "SUCCESSFUL": 11988,
+          "RUNNING": 0,
+          "overdue_running": 0,
+          "ledger_rows": 29406,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59584
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:20:32+00:00",
+          "elapsed_s": 428.1,
+          "FAILED": 688,
+          "READY": 15,
+          "RUNNING": 3,
+          "SUCCESSFUL": 12134,
+          "overdue_running": 0,
+          "ledger_rows": 29769,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59584
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:20:38+00:00",
+          "elapsed_s": 433.2,
+          "FAILED": 697,
+          "READY": 13,
+          "RUNNING": 4,
+          "SUCCESSFUL": 12279,
+          "overdue_running": 0,
+          "ledger_rows": 30109,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59584
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:20:43+00:00",
+          "elapsed_s": 438.3,
+          "FAILED": 703,
+          "READY": 19,
+          "RUNNING": 4,
+          "SUCCESSFUL": 12420,
+          "overdue_running": 0,
+          "ledger_rows": 30464,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59584
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:20:48+00:00",
+          "elapsed_s": 443.4,
+          "FAILED": 715,
+          "READY": 14,
+          "RUNNING": 7,
+          "SUCCESSFUL": 12563,
+          "overdue_running": 0,
+          "ledger_rows": 30831,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59584
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:20:53+00:00",
+          "elapsed_s": 448.5,
+          "FAILED": 724,
+          "READY": 10,
+          "RUNNING": 4,
+          "SUCCESSFUL": 12712,
+          "overdue_running": 0,
+          "ledger_rows": 31194,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59584
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:20:58+00:00",
+          "elapsed_s": 453.6,
+          "FAILED": 732,
+          "READY": 12,
+          "RUNNING": 1,
+          "SUCCESSFUL": 12857,
+          "overdue_running": 0,
+          "ledger_rows": 31541,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59584
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:21:03+00:00",
+          "elapsed_s": 458.7,
+          "FAILED": 739,
+          "READY": 20,
+          "RUNNING": 7,
+          "SUCCESSFUL": 12989,
+          "overdue_running": 0,
+          "ledger_rows": 31877,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59584
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:21:08+00:00",
+          "elapsed_s": 463.8,
+          "FAILED": 750,
+          "READY": 15,
+          "RUNNING": 6,
+          "SUCCESSFUL": 13137,
+          "overdue_running": 0,
+          "ledger_rows": 32256,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59584
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:21:13+00:00",
+          "elapsed_s": 468.9,
+          "FAILED": 761,
+          "READY": 10,
+          "RUNNING": 10,
+          "SUCCESSFUL": 13280,
+          "overdue_running": 0,
+          "ledger_rows": 32615,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59584
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:21:18+00:00",
+          "elapsed_s": 474.0,
+          "FAILED": 768,
+          "READY": 16,
+          "RUNNING": 1,
+          "SUCCESSFUL": 13429,
+          "overdue_running": 0,
+          "ledger_rows": 32981,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59584
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:21:23+00:00",
+          "elapsed_s": 479.1,
+          "FAILED": 779,
+          "READY": 15,
+          "RUNNING": 7,
+          "SUCCESSFUL": 13566,
+          "overdue_running": 0,
+          "ledger_rows": 33335,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59584
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:21:28+00:00",
+          "elapsed_s": 484.2,
+          "FAILED": 787,
+          "READY": 12,
+          "RUNNING": 4,
+          "SUCCESSFUL": 13717,
+          "overdue_running": 0,
+          "ledger_rows": 33692,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59584
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:21:34+00:00",
+          "elapsed_s": 489.3,
+          "FAILED": 792,
+          "READY": 15,
+          "RUNNING": 6,
+          "SUCCESSFUL": 13860,
+          "overdue_running": 0,
+          "ledger_rows": 34036,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59584
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:21:39+00:00",
+          "elapsed_s": 494.4,
+          "FAILED": 802,
+          "READY": 11,
+          "RUNNING": 5,
+          "SUCCESSFUL": 14008,
+          "overdue_running": 0,
+          "ledger_rows": 34393,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59584
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:21:44+00:00",
+          "elapsed_s": 499.5,
+          "FAILED": 808,
+          "READY": 16,
+          "RUNNING": 4,
+          "SUCCESSFUL": 14154,
+          "overdue_running": 0,
+          "ledger_rows": 34738,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59584
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:21:49+00:00",
+          "elapsed_s": 504.6,
+          "FAILED": 815,
+          "READY": 12,
+          "RUNNING": 4,
+          "SUCCESSFUL": 14304,
+          "overdue_running": 0,
+          "ledger_rows": 35090,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59584
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:21:54+00:00",
+          "elapsed_s": 509.7,
+          "FAILED": 822,
+          "READY": 12,
+          "RUNNING": 6,
+          "SUCCESSFUL": 14448,
+          "overdue_running": 0,
+          "ledger_rows": 35430,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59584
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:21:59+00:00",
+          "elapsed_s": 514.8,
+          "FAILED": 831,
+          "READY": 18,
+          "RUNNING": 5,
+          "SUCCESSFUL": 14587,
+          "overdue_running": 0,
+          "ledger_rows": 35777,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59584
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:22:04+00:00",
+          "elapsed_s": 519.9,
+          "FAILED": 839,
+          "READY": 22,
+          "RUNNING": 5,
+          "SUCCESSFUL": 14728,
+          "overdue_running": 0,
+          "ledger_rows": 36137,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59584
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:22:09+00:00",
+          "elapsed_s": 525.0,
+          "FAILED": 852,
+          "READY": 12,
+          "RUNNING": 5,
+          "SUCCESSFUL": 14878,
+          "overdue_running": 0,
+          "ledger_rows": 36516,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59584
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:22:14+00:00",
+          "elapsed_s": 530.2,
+          "FAILED": 857,
+          "READY": 22,
+          "RUNNING": 4,
+          "SUCCESSFUL": 15017,
+          "overdue_running": 0,
+          "ledger_rows": 36868,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59584
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:22:20+00:00",
+          "elapsed_s": 535.2,
+          "FAILED": 869,
+          "READY": 13,
+          "RUNNING": 6,
+          "SUCCESSFUL": 15165,
+          "overdue_running": 0,
+          "ledger_rows": 37229,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59584
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:22:25+00:00",
+          "elapsed_s": 540.4,
+          "FAILED": 877,
+          "READY": 13,
+          "RUNNING": 5,
+          "SUCCESSFUL": 15311,
+          "overdue_running": 0,
+          "ledger_rows": 37581,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59584
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:22:30+00:00",
+          "elapsed_s": 545.5,
+          "FAILED": 881,
+          "READY": 14,
+          "RUNNING": 3,
+          "SUCCESSFUL": 15461,
+          "overdue_running": 0,
+          "ledger_rows": 37931,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59584
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:22:35+00:00",
+          "elapsed_s": 550.5,
+          "FAILED": 890,
+          "READY": 18,
+          "RUNNING": 2,
+          "SUCCESSFUL": 15602,
+          "overdue_running": 0,
+          "ledger_rows": 38284,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59584
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:22:40+00:00",
+          "elapsed_s": 555.7,
+          "FAILED": 900,
+          "READY": 14,
+          "RUNNING": 3,
+          "SUCCESSFUL": 15748,
+          "overdue_running": 0,
+          "ledger_rows": 38649,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59616
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:22:45+00:00",
+          "elapsed_s": 560.7,
+          "FAILED": 909,
+          "READY": 12,
+          "RUNNING": 6,
+          "SUCCESSFUL": 15891,
+          "overdue_running": 0,
+          "ledger_rows": 38999,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59632
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:22:50+00:00",
+          "elapsed_s": 565.8,
+          "FAILED": 918,
+          "READY": 13,
+          "RUNNING": 2,
+          "SUCCESSFUL": 16038,
+          "overdue_running": 0,
+          "ledger_rows": 39352,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59632
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:22:55+00:00",
+          "elapsed_s": 570.9,
+          "FAILED": 927,
+          "READY": 15,
+          "RUNNING": 4,
+          "SUCCESSFUL": 16178,
+          "overdue_running": 0,
+          "ledger_rows": 39701,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59648
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:23:00+00:00",
+          "elapsed_s": 576.0,
+          "FAILED": 941,
+          "READY": 11,
+          "RUNNING": 5,
+          "SUCCESSFUL": 16320,
+          "overdue_running": 0,
+          "ledger_rows": 40071,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59648
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:23:05+00:00",
+          "elapsed_s": 581.1,
+          "FAILED": 947,
+          "READY": 22,
+          "RUNNING": 6,
+          "SUCCESSFUL": 16455,
+          "overdue_running": 0,
+          "ledger_rows": 40416,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59648
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59776
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:23:11+00:00",
+          "elapsed_s": 586.2,
+          "FAILED": 957,
+          "READY": 14,
+          "RUNNING": 6,
+          "SUCCESSFUL": 16606,
+          "overdue_running": 0,
+          "ledger_rows": 40787,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59648
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59808
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:23:16+00:00",
+          "elapsed_s": 591.4,
+          "FAILED": 965,
+          "READY": 12,
+          "RUNNING": 8,
+          "SUCCESSFUL": 16751,
+          "overdue_running": 0,
+          "ledger_rows": 41140,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59648
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59808
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:23:21+00:00",
+          "elapsed_s": 596.5,
+          "FAILED": 972,
+          "READY": 23,
+          "RUNNING": 4,
+          "SUCCESSFUL": 16890,
+          "overdue_running": 0,
+          "ledger_rows": 41490,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59648
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59808
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:23:26+00:00",
+          "elapsed_s": 601.6,
+          "FAILED": 982,
+          "READY": 20,
+          "RUNNING": 5,
+          "SUCCESSFUL": 17035,
+          "overdue_running": 0,
+          "ledger_rows": 41855,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59648
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59808
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:23:31+00:00",
+          "elapsed_s": 606.7,
+          "FAILED": 994,
+          "READY": 12,
+          "RUNNING": 4,
+          "SUCCESSFUL": 17185,
+          "overdue_running": 0,
+          "ledger_rows": 42229,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59648
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59808
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:23:36+00:00",
+          "elapsed_s": 611.8,
+          "FAILED": 1000,
+          "READY": 13,
+          "RUNNING": 5,
+          "SUCCESSFUL": 17330,
+          "overdue_running": 0,
+          "ledger_rows": 42583,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59648
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59808
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:23:41+00:00",
+          "elapsed_s": 616.9,
+          "FAILED": 1008,
+          "READY": 20,
+          "RUNNING": 3,
+          "SUCCESSFUL": 17470,
+          "overdue_running": 0,
+          "ledger_rows": 42928,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59648
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59808
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:23:46+00:00",
+          "elapsed_s": 622.0,
+          "FAILED": 1017,
+          "READY": 16,
+          "RUNNING": 6,
+          "SUCCESSFUL": 17615,
+          "overdue_running": 0,
+          "ledger_rows": 43304,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59648
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59808
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:23:51+00:00",
+          "elapsed_s": 627.0,
+          "FAILED": 1026,
+          "READY": 13,
+          "RUNNING": 5,
+          "SUCCESSFUL": 17763,
+          "overdue_running": 0,
+          "ledger_rows": 43669,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59648
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59808
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:23:56+00:00",
+          "elapsed_s": 632.1,
+          "FAILED": 1035,
+          "READY": 9,
+          "RUNNING": 9,
+          "SUCCESSFUL": 17907,
+          "overdue_running": 0,
+          "ledger_rows": 44028,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59648
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59808
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:24:01+00:00",
+          "elapsed_s": 637.2,
+          "FAILED": 1041,
+          "READY": 6,
+          "RUNNING": 7,
+          "SUCCESSFUL": 18056,
+          "overdue_running": 0,
+          "ledger_rows": 44356,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59648
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59808
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:24:07+00:00",
+          "elapsed_s": 642.3,
+          "FAILED": 1044,
+          "READY": 13,
+          "RUNNING": 3,
+          "SUCCESSFUL": 18203,
+          "overdue_running": 0,
+          "ledger_rows": 44699,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59648
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59808
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:24:12+00:00",
+          "elapsed_s": 647.4,
+          "FAILED": 1054,
+          "READY": 14,
+          "RUNNING": 5,
+          "SUCCESSFUL": 18343,
+          "overdue_running": 0,
+          "ledger_rows": 45050,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59648
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59808
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:24:17+00:00",
+          "elapsed_s": 652.5,
+          "FAILED": 1063,
+          "READY": 12,
+          "RUNNING": 4,
+          "SUCCESSFUL": 18490,
+          "overdue_running": 0,
+          "ledger_rows": 45412,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59648
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59808
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:24:22+00:00",
+          "elapsed_s": 657.6,
+          "FAILED": 1071,
+          "READY": 13,
+          "RUNNING": 2,
+          "SUCCESSFUL": 18636,
+          "overdue_running": 0,
+          "ledger_rows": 45765,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59648
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59808
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:24:27+00:00",
+          "elapsed_s": 662.7,
+          "FAILED": 1076,
+          "READY": 17,
+          "RUNNING": 4,
+          "SUCCESSFUL": 18778,
+          "overdue_running": 0,
+          "ledger_rows": 46114,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59648
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59808
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:24:32+00:00",
+          "elapsed_s": 667.8,
+          "FAILED": 1085,
+          "READY": 15,
+          "RUNNING": 6,
+          "SUCCESSFUL": 18922,
+          "overdue_running": 0,
+          "ledger_rows": 46475,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59648
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59808
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:24:37+00:00",
+          "elapsed_s": 672.9,
+          "FAILED": 1095,
+          "READY": 10,
+          "RUNNING": 3,
+          "SUCCESSFUL": 19073,
+          "overdue_running": 0,
+          "ledger_rows": 46834,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59648
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59808
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:24:42+00:00",
+          "elapsed_s": 677.9,
+          "FAILED": 1100,
+          "READY": 15,
+          "RUNNING": 6,
+          "SUCCESSFUL": 19213,
+          "overdue_running": 0,
+          "ledger_rows": 47176,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59648
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59808
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:24:47+00:00",
+          "elapsed_s": 683.1,
+          "FAILED": 1112,
+          "READY": 15,
+          "RUNNING": 4,
+          "SUCCESSFUL": 19356,
+          "overdue_running": 0,
+          "ledger_rows": 47522,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59648
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59808
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:24:52+00:00",
+          "elapsed_s": 688.1,
+          "FAILED": 1119,
+          "READY": 17,
+          "RUNNING": 1,
+          "SUCCESSFUL": 19503,
+          "overdue_running": 0,
+          "ledger_rows": 47869,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59648
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59808
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:24:58+00:00",
+          "elapsed_s": 693.3,
+          "FAILED": 1125,
+          "READY": 14,
+          "RUNNING": 6,
+          "SUCCESSFUL": 19648,
+          "overdue_running": 0,
+          "ledger_rows": 48226,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59648
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59808
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:25:03+00:00",
+          "elapsed_s": 698.4,
+          "FAILED": 1136,
+          "READY": 15,
+          "RUNNING": 8,
+          "SUCCESSFUL": 19787,
+          "overdue_running": 0,
+          "ledger_rows": 48583,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59648
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59808
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:25:08+00:00",
+          "elapsed_s": 703.4,
+          "FAILED": 1144,
+          "READY": 15,
+          "RUNNING": 8,
+          "SUCCESSFUL": 19932,
+          "overdue_running": 0,
+          "ledger_rows": 48947,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59648
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59808
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:25:13+00:00",
+          "elapsed_s": 708.5,
+          "FAILED": 1155,
+          "READY": 13,
+          "RUNNING": 6,
+          "SUCCESSFUL": 20078,
+          "overdue_running": 0,
+          "ledger_rows": 49296,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59648
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59808
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:25:18+00:00",
+          "elapsed_s": 713.6,
+          "FAILED": 1163,
+          "READY": 12,
+          "RUNNING": 2,
+          "SUCCESSFUL": 20228,
+          "overdue_running": 0,
+          "ledger_rows": 49641,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59648
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59808
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:25:23+00:00",
+          "elapsed_s": 718.7,
+          "FAILED": 1167,
+          "READY": 16,
+          "RUNNING": 3,
+          "SUCCESSFUL": 20372,
+          "overdue_running": 0,
+          "ledger_rows": 49971,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59648
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59808
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:25:28+00:00",
+          "elapsed_s": 724.1,
+          "FAILED": 1172,
+          "READY": 2,
+          "SUCCESSFUL": 20426,
+          "RUNNING": 0,
+          "overdue_running": 0,
+          "ledger_rows": 50102,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59648
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59808
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:25:31+00:00",
+          "elapsed_s": 726.3,
+          "FAILED": 1174,
+          "SUCCESSFUL": 20426,
+          "READY": 0,
+          "RUNNING": 0,
+          "overdue_running": 0,
+          "ledger_rows": 50106,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 96867,
+              "rss_kb": 59648
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 96868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 96869,
+              "rss_kb": 59808
+            }
+          ]
+        }
+      ],
+      "analysis": {
+        "status_counts": {
+          "SUCCESSFUL": 20426,
+          "FAILED": 1174
+        },
+        "per_type": {
+          "doomed": {
+            "FAILED": 1174
+          },
+          "flaky_once": {
+            "SUCCESSFUL": 1105
+          },
+          "medium": {
+            "SUCCESSFUL": 3192
+          },
+          "quick": {
+            "SUCCESSFUL": 14990
+          },
+          "slow": {
+            "SUCCESSFUL": 1139
+          }
+        },
+        "enqueued_by_producers": 21600,
+        "task_rows": 21600,
+        "executions": 25053,
+        "ledger_rows": 50106,
+        "completions_histogram": {
+          "1": 20426
+        },
+        "double_completed": [],
+        "interrupted_executions": 0,
+        "reclaim_delays_s": [],
+        "reclaim_bound_s": 37.5,
+        "claim_window_missing_starts": 0,
+        "max_overdue_running": 0,
+        "max_ready_backlog": 26,
+        "latency_first_attempt": {
+          "all": {
+            "count": 19321,
+            "p50_s": 0.122,
+            "p95_s": 1.526,
+            "p99_s": 1.636,
+            "max_s": 1.733
+          },
+          "medium": {
+            "count": 3192,
+            "p50_s": 0.266,
+            "p95_s": 0.39,
+            "p99_s": 0.42,
+            "max_s": 0.467
+          },
+          "quick": {
+            "count": 14990,
+            "p50_s": 0.096,
+            "p95_s": 0.214,
+            "p99_s": 0.244,
+            "max_s": 0.284
+          },
+          "slow": {
+            "count": 1139,
+            "p50_s": 1.565,
+            "p95_s": 1.682,
+            "p99_s": 1.709,
+            "max_s": 1.733
+          }
+        },
+        "assertions": [
+          {
+            "assertion": "every enqueued task has a row",
+            "passed": true,
+            "observed": "producers reported 21600, table has 21600"
+          },
+          {
+            "assertion": "all tasks terminal after drain",
+            "passed": true,
+            "observed": "drained=True, non-terminal rows=0"
+          },
+          {
+            "assertion": "no lock older than 27.5s in any live sample",
+            "passed": true,
+            "observed": "max overdue RUNNING rows across 144 samples: 0"
+          },
+          {
+            "assertion": "attempts never exceed max_attempts",
+            "passed": true,
+            "observed": "violations: 0"
+          },
+          {
+            "assertion": "attempts == len(worker_ids) on every row",
+            "passed": true,
+            "observed": "violations: 0"
+          },
+          {
+            "assertion": "every SUCCESSFUL task has >= 1 ledger completion",
+            "passed": true,
+            "observed": "phantom successes: 0"
+          },
+          {
+            "assertion": "exactly-once completions without chaos",
+            "passed": true,
+            "observed": "double-completed tasks: 0"
+          },
+          {
+            "assertion": "interrupted executions re-executed or abandoned",
+            "passed": true,
+            "observed": "interrupted: 0, re-executed: 0, abandoned: 0, unresolved: 0"
+          },
+          {
+            "assertion": "re-execution within 37.5s of interrupted start",
+            "passed": true,
+            "observed": "no interrupted executions were re-executed"
+          },
+          {
+            "assertion": "all doomed tasks FAILED with attempts == max_attempts",
+            "passed": true,
+            "observed": "doomed: 1174, failed: 1174"
+          },
+          {
+            "assertion": "no organic failures outside doomed",
+            "passed": true,
+            "observed": "unexplained FAILED rows: 0, flaky_once FAILED (chaos-consumed attempts): 0"
+          },
+          {
+            "assertion": "no unexpected worker exits",
+            "passed": true,
+            "observed": "unexpected exits: 0"
+          }
+        ]
+      }
+    },
+    {
+      "config": {
+        "name": "chaos",
+        "kind": "load",
+        "duration": 540.0,
+        "producers": 3,
+        "rate": 10.0,
+        "workers": 3,
+        "concurrency": 4,
+        "chaos": {
+          "min_gap": 20.0,
+          "max_gap": 45.0,
+          "restart_min": 2.0,
+          "restart_max": 5.0
+        },
+        "drain_timeout": 300.0
+      },
+      "seed": 350589,
+      "started_at": "2026-09-01T13:25:31+00:00",
+      "load_seconds": 540.5,
+      "wall_seconds": 549.4,
+      "kills": 17,
+      "drained": true,
+      "producers": [
+        {
+          "returncode": 0,
+          "log": "soak-chaos-producer0.log",
+          "enqueued": 5400,
+          "by_type": {
+            "quick": 3785,
+            "doomed": 291,
+            "medium": 801,
+            "slow": 264,
+            "flaky_once": 259
+          }
+        },
+        {
+          "returncode": 0,
+          "log": "soak-chaos-producer1.log",
+          "enqueued": 5400,
+          "by_type": {
+            "quick": 3715,
+            "doomed": 313,
+            "medium": 789,
+            "flaky_once": 297,
+            "slow": 286
+          }
+        },
+        {
+          "returncode": 0,
+          "log": "soak-chaos-producer2.log",
+          "enqueued": 5400,
+          "by_type": {
+            "quick": 3752,
+            "flaky_once": 279,
+            "medium": 783,
+            "doomed": 280,
+            "slow": 306
+          }
+        }
+      ],
+      "events": [
+        {
+          "at": "2026-09-01T13:25:31+00:00",
+          "event": "worker_started",
+          "slot": 0,
+          "gen": 1,
+          "pid": 2606
+        },
+        {
+          "at": "2026-09-01T13:25:31+00:00",
+          "event": "worker_started",
+          "slot": 1,
+          "gen": 1,
+          "pid": 2607
+        },
+        {
+          "at": "2026-09-01T13:25:31+00:00",
+          "event": "worker_started",
+          "slot": 2,
+          "gen": 1,
+          "pid": 2608
+        },
+        {
+          "at": "2026-09-01T13:25:59+00:00",
+          "event": "worker_killed",
+          "slot": 2,
+          "gen": 1,
+          "pid": 2608
+        },
+        {
+          "at": "2026-09-01T13:26:03+00:00",
+          "event": "worker_started",
+          "slot": 2,
+          "gen": 2,
+          "pid": 2735
+        },
+        {
+          "at": "2026-09-01T13:26:23+00:00",
+          "event": "worker_killed",
+          "slot": 0,
+          "gen": 1,
+          "pid": 2606
+        },
+        {
+          "at": "2026-09-01T13:26:28+00:00",
+          "event": "worker_started",
+          "slot": 0,
+          "gen": 2,
+          "pid": 2868
+        },
+        {
+          "at": "2026-09-01T13:27:06+00:00",
+          "event": "worker_killed",
+          "slot": 2,
+          "gen": 2,
+          "pid": 2735
+        },
+        {
+          "at": "2026-09-01T13:27:11+00:00",
+          "event": "worker_started",
+          "slot": 2,
+          "gen": 3,
+          "pid": 3086
+        },
+        {
+          "at": "2026-09-01T13:27:49+00:00",
+          "event": "worker_killed",
+          "slot": 1,
+          "gen": 1,
+          "pid": 2607
+        },
+        {
+          "at": "2026-09-01T13:27:53+00:00",
+          "event": "worker_started",
+          "slot": 1,
+          "gen": 2,
+          "pid": 3269
+        },
+        {
+          "at": "2026-09-01T13:28:20+00:00",
+          "event": "worker_killed",
+          "slot": 0,
+          "gen": 2,
+          "pid": 2868
+        },
+        {
+          "at": "2026-09-01T13:28:25+00:00",
+          "event": "worker_started",
+          "slot": 0,
+          "gen": 3,
+          "pid": 3439
+        },
+        {
+          "at": "2026-09-01T13:28:41+00:00",
+          "event": "worker_killed",
+          "slot": 1,
+          "gen": 2,
+          "pid": 3269
+        },
+        {
+          "at": "2026-09-01T13:28:45+00:00",
+          "event": "worker_started",
+          "slot": 1,
+          "gen": 3,
+          "pid": 3551
+        },
+        {
+          "at": "2026-09-01T13:29:11+00:00",
+          "event": "worker_killed",
+          "slot": 2,
+          "gen": 3,
+          "pid": 3086
+        },
+        {
+          "at": "2026-09-01T13:29:15+00:00",
+          "event": "worker_started",
+          "slot": 2,
+          "gen": 4,
+          "pid": 3721
+        },
+        {
+          "at": "2026-09-01T13:29:37+00:00",
+          "event": "worker_killed",
+          "slot": 0,
+          "gen": 3,
+          "pid": 3439
+        },
+        {
+          "at": "2026-09-01T13:29:39+00:00",
+          "event": "worker_started",
+          "slot": 0,
+          "gen": 4,
+          "pid": 3815
+        },
+        {
+          "at": "2026-09-01T13:30:20+00:00",
+          "event": "worker_killed",
+          "slot": 0,
+          "gen": 4,
+          "pid": 3815
+        },
+        {
+          "at": "2026-09-01T13:30:22+00:00",
+          "event": "worker_started",
+          "slot": 0,
+          "gen": 5,
+          "pid": 3967
+        },
+        {
+          "at": "2026-09-01T13:30:48+00:00",
+          "event": "worker_killed",
+          "slot": 2,
+          "gen": 4,
+          "pid": 3721
+        },
+        {
+          "at": "2026-09-01T13:30:53+00:00",
+          "event": "worker_started",
+          "slot": 2,
+          "gen": 5,
+          "pid": 4152
+        },
+        {
+          "at": "2026-09-01T13:31:27+00:00",
+          "event": "worker_killed",
+          "slot": 1,
+          "gen": 3,
+          "pid": 3551
+        },
+        {
+          "at": "2026-09-01T13:31:30+00:00",
+          "event": "worker_started",
+          "slot": 1,
+          "gen": 4,
+          "pid": 4449
+        },
+        {
+          "at": "2026-09-01T13:32:03+00:00",
+          "event": "worker_killed",
+          "slot": 0,
+          "gen": 5,
+          "pid": 3967
+        },
+        {
+          "at": "2026-09-01T13:32:07+00:00",
+          "event": "worker_started",
+          "slot": 0,
+          "gen": 6,
+          "pid": 4889
+        },
+        {
+          "at": "2026-09-01T13:32:40+00:00",
+          "event": "worker_killed",
+          "slot": 1,
+          "gen": 4,
+          "pid": 4449
+        },
+        {
+          "at": "2026-09-01T13:32:44+00:00",
+          "event": "worker_started",
+          "slot": 1,
+          "gen": 5,
+          "pid": 5053
+        },
+        {
+          "at": "2026-09-01T13:33:03+00:00",
+          "event": "worker_killed",
+          "slot": 1,
+          "gen": 5,
+          "pid": 5053
+        },
+        {
+          "at": "2026-09-01T13:33:07+00:00",
+          "event": "worker_started",
+          "slot": 1,
+          "gen": 6,
+          "pid": 5174
+        },
+        {
+          "at": "2026-09-01T13:33:25+00:00",
+          "event": "worker_killed",
+          "slot": 1,
+          "gen": 6,
+          "pid": 5174
+        },
+        {
+          "at": "2026-09-01T13:33:29+00:00",
+          "event": "worker_started",
+          "slot": 1,
+          "gen": 7,
+          "pid": 5262
+        },
+        {
+          "at": "2026-09-01T13:34:02+00:00",
+          "event": "worker_killed",
+          "slot": 1,
+          "gen": 7,
+          "pid": 5262
+        },
+        {
+          "at": "2026-09-01T13:34:06+00:00",
+          "event": "worker_started",
+          "slot": 1,
+          "gen": 8,
+          "pid": 5373
+        },
+        {
+          "at": "2026-09-01T13:34:23+00:00",
+          "event": "worker_killed",
+          "slot": 1,
+          "gen": 8,
+          "pid": 5373
+        },
+        {
+          "at": "2026-09-01T13:34:27+00:00",
+          "event": "worker_started",
+          "slot": 1,
+          "gen": 9,
+          "pid": 5442
+        },
+        {
+          "at": "2026-09-01T13:34:40+00:00",
+          "event": "worker_stopping",
+          "slot": 0,
+          "gen": 6,
+          "pid": 4889
+        },
+        {
+          "at": "2026-09-01T13:34:40+00:00",
+          "event": "worker_stopping",
+          "slot": 1,
+          "gen": 9,
+          "pid": 5442
+        },
+        {
+          "at": "2026-09-01T13:34:40+00:00",
+          "event": "worker_stopping",
+          "slot": 2,
+          "gen": 5,
+          "pid": 4152
+        }
+      ],
+      "rss": [
+        {
+          "slot": 0,
+          "gen": 1,
+          "samples": 11,
+          "first_kb": 12368,
+          "last_kb": 58944,
+          "max_kb": 58944,
+          "first_at_s": 0.0,
+          "last_at_s": 51.0
+        },
+        {
+          "slot": 0,
+          "gen": 2,
+          "samples": 22,
+          "first_kb": 58352,
+          "last_kb": 59424,
+          "max_kb": 59424,
+          "first_at_s": 61.2,
+          "last_at_s": 168.3
+        },
+        {
+          "slot": 0,
+          "gen": 3,
+          "samples": 14,
+          "first_kb": 58192,
+          "last_kb": 59072,
+          "max_kb": 59072,
+          "first_at_s": 178.5,
+          "last_at_s": 244.8
+        },
+        {
+          "slot": 0,
+          "gen": 4,
+          "samples": 8,
+          "first_kb": 58128,
+          "last_kb": 58768,
+          "max_kb": 58768,
+          "first_at_s": 249.9,
+          "last_at_s": 285.7
+        },
+        {
+          "slot": 0,
+          "gen": 5,
+          "samples": 19,
+          "first_kb": 58352,
+          "last_kb": 59328,
+          "max_kb": 59328,
+          "first_at_s": 295.8,
+          "last_at_s": 387.6
+        },
+        {
+          "slot": 0,
+          "gen": 6,
+          "samples": 31,
+          "first_kb": 57968,
+          "last_kb": 59168,
+          "max_kb": 59168,
+          "first_at_s": 397.8,
+          "last_at_s": 549.3
+        },
+        {
+          "slot": 1,
+          "gen": 1,
+          "samples": 27,
+          "first_kb": 12272,
+          "last_kb": 59120,
+          "max_kb": 59120,
+          "first_at_s": 0.0,
+          "last_at_s": 132.6
+        },
+        {
+          "slot": 1,
+          "gen": 2,
+          "samples": 10,
+          "first_kb": 57712,
+          "last_kb": 58960,
+          "max_kb": 58960,
+          "first_at_s": 142.8,
+          "last_at_s": 188.7
+        },
+        {
+          "slot": 1,
+          "gen": 3,
+          "samples": 32,
+          "first_kb": 11008,
+          "last_kb": 59424,
+          "max_kb": 59424,
+          "first_at_s": 193.8,
+          "last_at_s": 351.9
+        },
+        {
+          "slot": 1,
+          "gen": 4,
+          "samples": 14,
+          "first_kb": 58304,
+          "last_kb": 59232,
+          "max_kb": 59232,
+          "first_at_s": 362.0,
+          "last_at_s": 428.5
+        },
+        {
+          "slot": 1,
+          "gen": 5,
+          "samples": 4,
+          "first_kb": 56752,
+          "last_kb": 58272,
+          "max_kb": 58272,
+          "first_at_s": 433.6,
+          "last_at_s": 448.9
+        },
+        {
+          "slot": 1,
+          "gen": 6,
+          "samples": 3,
+          "first_kb": 58320,
+          "last_kb": 58560,
+          "max_kb": 58560,
+          "first_at_s": 459.1,
+          "last_at_s": 469.4
+        },
+        {
+          "slot": 1,
+          "gen": 7,
+          "samples": 7,
+          "first_kb": 58160,
+          "last_kb": 58688,
+          "max_kb": 58688,
+          "first_at_s": 479.6,
+          "last_at_s": 510.3
+        },
+        {
+          "slot": 1,
+          "gen": 8,
+          "samples": 4,
+          "first_kb": 12896,
+          "last_kb": 58496,
+          "max_kb": 58496,
+          "first_at_s": 515.5,
+          "last_at_s": 530.8
+        },
+        {
+          "slot": 1,
+          "gen": 9,
+          "samples": 3,
+          "first_kb": 58416,
+          "last_kb": 58416,
+          "max_kb": 58416,
+          "first_at_s": 541.0,
+          "last_at_s": 549.3
+        },
+        {
+          "slot": 2,
+          "gen": 1,
+          "samples": 6,
+          "first_kb": 12272,
+          "last_kb": 58432,
+          "max_kb": 58432,
+          "first_at_s": 0.0,
+          "last_at_s": 25.5
+        },
+        {
+          "slot": 2,
+          "gen": 2,
+          "samples": 12,
+          "first_kb": 58272,
+          "last_kb": 59008,
+          "max_kb": 59008,
+          "first_at_s": 35.7,
+          "last_at_s": 91.8
+        },
+        {
+          "slot": 2,
+          "gen": 3,
+          "samples": 24,
+          "first_kb": 57984,
+          "last_kb": 59184,
+          "max_kb": 59184,
+          "first_at_s": 102.0,
+          "last_at_s": 219.3
+        },
+        {
+          "slot": 2,
+          "gen": 4,
+          "samples": 19,
+          "first_kb": 10800,
+          "last_kb": 59232,
+          "max_kb": 59232,
+          "first_at_s": 224.4,
+          "last_at_s": 316.2
+        },
+        {
+          "slot": 2,
+          "gen": 5,
+          "samples": 45,
+          "first_kb": 58256,
+          "last_kb": 59456,
+          "max_kb": 59456,
+          "first_at_s": 326.4,
+          "last_at_s": 549.3
+        }
+      ],
+      "samples": [
+        {
+          "t": "2026-09-01T13:25:31+00:00",
+          "elapsed_s": 0.0,
+          "READY": 0,
+          "RUNNING": 0,
+          "SUCCESSFUL": 0,
+          "FAILED": 0,
+          "overdue_running": 0,
+          "ledger_rows": 0,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 2606,
+              "rss_kb": 12368
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 2607,
+              "rss_kb": 12272
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 2608,
+              "rss_kb": 12272
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:25:36+00:00",
+          "elapsed_s": 5.1,
+          "RUNNING": 4,
+          "SUCCESSFUL": 129,
+          "READY": 11,
+          "FAILED": 0,
+          "overdue_running": 0,
+          "ledger_rows": 300,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 2606,
+              "rss_kb": 58192
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 2607,
+              "rss_kb": 58032
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 2608,
+              "rss_kb": 58112
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:25:41+00:00",
+          "elapsed_s": 10.2,
+          "RUNNING": 3,
+          "FAILED": 5,
+          "SUCCESSFUL": 277,
+          "READY": 12,
+          "overdue_running": 0,
+          "ledger_rows": 647,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 2606,
+              "rss_kb": 58352
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 2607,
+              "rss_kb": 58144
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 2608,
+              "rss_kb": 58256
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:25:46+00:00",
+          "elapsed_s": 15.3,
+          "RUNNING": 4,
+          "FAILED": 13,
+          "SUCCESSFUL": 421,
+          "READY": 12,
+          "overdue_running": 0,
+          "ledger_rows": 984,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 2606,
+              "rss_kb": 58480
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 2607,
+              "rss_kb": 58288
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 2608,
+              "rss_kb": 58336
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:25:51+00:00",
+          "elapsed_s": 20.4,
+          "RUNNING": 5,
+          "FAILED": 20,
+          "SUCCESSFUL": 557,
+          "READY": 21,
+          "overdue_running": 0,
+          "ledger_rows": 1339,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 2606,
+              "rss_kb": 58512
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 2607,
+              "rss_kb": 58336
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 2608,
+              "rss_kb": 58368
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:25:56+00:00",
+          "elapsed_s": 25.5,
+          "RUNNING": 4,
+          "FAILED": 29,
+          "SUCCESSFUL": 702,
+          "READY": 21,
+          "overdue_running": 0,
+          "ledger_rows": 1710,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 2606,
+              "rss_kb": 58608
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 2607,
+              "rss_kb": 58416
+            },
+            {
+              "slot": 2,
+              "gen": 1,
+              "pid": 2608,
+              "rss_kb": 58432
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:26:01+00:00",
+          "elapsed_s": 30.6,
+          "RUNNING": 10,
+          "FAILED": 41,
+          "SUCCESSFUL": 848,
+          "READY": 10,
+          "overdue_running": 0,
+          "ledger_rows": 2069,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 2606,
+              "rss_kb": 58720
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 2607,
+              "rss_kb": 58464
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:26:07+00:00",
+          "elapsed_s": 35.7,
+          "RUNNING": 5,
+          "FAILED": 46,
+          "SUCCESSFUL": 996,
+          "READY": 15,
+          "overdue_running": 0,
+          "ledger_rows": 2411,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 2606,
+              "rss_kb": 58784
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 2607,
+              "rss_kb": 58544
+            },
+            {
+              "slot": 2,
+              "gen": 2,
+              "pid": 2735,
+              "rss_kb": 58272
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:26:12+00:00",
+          "elapsed_s": 40.8,
+          "RUNNING": 7,
+          "FAILED": 53,
+          "SUCCESSFUL": 1148,
+          "READY": 10,
+          "overdue_running": 0,
+          "ledger_rows": 2773,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 2606,
+              "rss_kb": 58832
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 2607,
+              "rss_kb": 58576
+            },
+            {
+              "slot": 2,
+              "gen": 2,
+              "pid": 2735,
+              "rss_kb": 58384
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:26:17+00:00",
+          "elapsed_s": 45.9,
+          "FAILED": 58,
+          "READY": 12,
+          "RUNNING": 5,
+          "SUCCESSFUL": 1293,
+          "overdue_running": 0,
+          "ledger_rows": 3119,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 2606,
+              "rss_kb": 58896
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 2607,
+              "rss_kb": 58592
+            },
+            {
+              "slot": 2,
+              "gen": 2,
+              "pid": 2735,
+              "rss_kb": 58464
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:26:22+00:00",
+          "elapsed_s": 51.0,
+          "FAILED": 65,
+          "READY": 17,
+          "RUNNING": 5,
+          "SUCCESSFUL": 1434,
+          "overdue_running": 0,
+          "ledger_rows": 3471,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 2606,
+              "rss_kb": 58944
+            },
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 2607,
+              "rss_kb": 58624
+            },
+            {
+              "slot": 2,
+              "gen": 2,
+              "pid": 2735,
+              "rss_kb": 58512
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:26:27+00:00",
+          "elapsed_s": 56.1,
+          "FAILED": 80,
+          "READY": 8,
+          "RUNNING": 8,
+          "SUCCESSFUL": 1581,
+          "overdue_running": 0,
+          "ledger_rows": 3821,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 2607,
+              "rss_kb": 58736
+            },
+            {
+              "slot": 2,
+              "gen": 2,
+              "pid": 2735,
+              "rss_kb": 58640
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:26:32+00:00",
+          "elapsed_s": 61.2,
+          "FAILED": 83,
+          "READY": 15,
+          "RUNNING": 9,
+          "SUCCESSFUL": 1720,
+          "overdue_running": 0,
+          "ledger_rows": 4155,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 2607,
+              "rss_kb": 58784
+            },
+            {
+              "slot": 2,
+              "gen": 2,
+              "pid": 2735,
+              "rss_kb": 58704
+            },
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 2868,
+              "rss_kb": 58352
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:26:37+00:00",
+          "elapsed_s": 66.3,
+          "FAILED": 94,
+          "READY": 11,
+          "RUNNING": 9,
+          "SUCCESSFUL": 1866,
+          "overdue_running": 0,
+          "ledger_rows": 4513,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 2607,
+              "rss_kb": 58816
+            },
+            {
+              "slot": 2,
+              "gen": 2,
+              "pid": 2735,
+              "rss_kb": 58752
+            },
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 2868,
+              "rss_kb": 58544
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:26:42+00:00",
+          "elapsed_s": 71.4,
+          "FAILED": 103,
+          "SUCCESSFUL": 2014,
+          "READY": 16,
+          "RUNNING": 0,
+          "overdue_running": 0,
+          "ledger_rows": 4890,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 2607,
+              "rss_kb": 58848
+            },
+            {
+              "slot": 2,
+              "gen": 2,
+              "pid": 2735,
+              "rss_kb": 58784
+            },
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 2868,
+              "rss_kb": 58688
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:26:47+00:00",
+          "elapsed_s": 76.5,
+          "RUNNING": 5,
+          "FAILED": 114,
+          "SUCCESSFUL": 2157,
+          "READY": 10,
+          "overdue_running": 0,
+          "ledger_rows": 5244,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 2607,
+              "rss_kb": 58912
+            },
+            {
+              "slot": 2,
+              "gen": 2,
+              "pid": 2735,
+              "rss_kb": 58864
+            },
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 2868,
+              "rss_kb": 58720
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:26:53+00:00",
+          "elapsed_s": 81.6,
+          "RUNNING": 2,
+          "FAILED": 122,
+          "SUCCESSFUL": 2303,
+          "READY": 12,
+          "overdue_running": 0,
+          "ledger_rows": 5580,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 2607,
+              "rss_kb": 58976
+            },
+            {
+              "slot": 2,
+              "gen": 2,
+              "pid": 2735,
+              "rss_kb": 58912
+            },
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 2868,
+              "rss_kb": 58800
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:26:58+00:00",
+          "elapsed_s": 86.7,
+          "RUNNING": 5,
+          "FAILED": 127,
+          "SUCCESSFUL": 2444,
+          "READY": 16,
+          "overdue_running": 0,
+          "ledger_rows": 5923,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 2607,
+              "rss_kb": 58992
+            },
+            {
+              "slot": 2,
+              "gen": 2,
+              "pid": 2735,
+              "rss_kb": 58960
+            },
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 2868,
+              "rss_kb": 58832
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:27:03+00:00",
+          "elapsed_s": 91.8,
+          "RUNNING": 3,
+          "FAILED": 139,
+          "SUCCESSFUL": 2587,
+          "READY": 16,
+          "overdue_running": 0,
+          "ledger_rows": 6287,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 2607,
+              "rss_kb": 59024
+            },
+            {
+              "slot": 2,
+              "gen": 2,
+              "pid": 2735,
+              "rss_kb": 59008
+            },
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 2868,
+              "rss_kb": 58864
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:27:08+00:00",
+          "elapsed_s": 96.9,
+          "RUNNING": 6,
+          "FAILED": 149,
+          "SUCCESSFUL": 2728,
+          "READY": 15,
+          "overdue_running": 0,
+          "ledger_rows": 6650,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 2607,
+              "rss_kb": 59024
+            },
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 2868,
+              "rss_kb": 58912
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:27:13+00:00",
+          "elapsed_s": 102.0,
+          "RUNNING": 4,
+          "FAILED": 158,
+          "SUCCESSFUL": 2871,
+          "READY": 18,
+          "overdue_running": 0,
+          "ledger_rows": 7004,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 2607,
+              "rss_kb": 59040
+            },
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 2868,
+              "rss_kb": 58992
+            },
+            {
+              "slot": 2,
+              "gen": 3,
+              "pid": 3086,
+              "rss_kb": 57984
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:27:18+00:00",
+          "elapsed_s": 107.1,
+          "FAILED": 170,
+          "READY": 17,
+          "RUNNING": 7,
+          "SUCCESSFUL": 3010,
+          "overdue_running": 0,
+          "ledger_rows": 7372,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 2607,
+              "rss_kb": 59040
+            },
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 2868,
+              "rss_kb": 59088
+            },
+            {
+              "slot": 2,
+              "gen": 3,
+              "pid": 3086,
+              "rss_kb": 58272
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:27:23+00:00",
+          "elapsed_s": 112.2,
+          "FAILED": 181,
+          "READY": 20,
+          "RUNNING": 2,
+          "SUCCESSFUL": 3157,
+          "overdue_running": 0,
+          "ledger_rows": 7741,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 2607,
+              "rss_kb": 59072
+            },
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 2868,
+              "rss_kb": 59120
+            },
+            {
+              "slot": 2,
+              "gen": 3,
+              "pid": 3086,
+              "rss_kb": 58432
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:27:28+00:00",
+          "elapsed_s": 117.3,
+          "FAILED": 189,
+          "READY": 11,
+          "RUNNING": 3,
+          "SUCCESSFUL": 3310,
+          "overdue_running": 0,
+          "ledger_rows": 8107,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 2607,
+              "rss_kb": 59072
+            },
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 2868,
+              "rss_kb": 59168
+            },
+            {
+              "slot": 2,
+              "gen": 3,
+              "pid": 3086,
+              "rss_kb": 58496
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:27:33+00:00",
+          "elapsed_s": 122.4,
+          "FAILED": 196,
+          "READY": 14,
+          "RUNNING": 5,
+          "SUCCESSFUL": 3451,
+          "overdue_running": 0,
+          "ledger_rows": 8441,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 2607,
+              "rss_kb": 59072
+            },
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 2868,
+              "rss_kb": 59184
+            },
+            {
+              "slot": 2,
+              "gen": 3,
+              "pid": 3086,
+              "rss_kb": 58560
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:27:38+00:00",
+          "elapsed_s": 127.5,
+          "FAILED": 199,
+          "READY": 17,
+          "RUNNING": 5,
+          "SUCCESSFUL": 3595,
+          "overdue_running": 0,
+          "ledger_rows": 8784,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 2607,
+              "rss_kb": 59104
+            },
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 2868,
+              "rss_kb": 59200
+            },
+            {
+              "slot": 2,
+              "gen": 3,
+              "pid": 3086,
+              "rss_kb": 58608
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:27:44+00:00",
+          "elapsed_s": 132.6,
+          "FAILED": 208,
+          "READY": 16,
+          "RUNNING": 6,
+          "SUCCESSFUL": 3739,
+          "overdue_running": 0,
+          "ledger_rows": 9165,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 1,
+              "pid": 2607,
+              "rss_kb": 59120
+            },
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 2868,
+              "rss_kb": 59264
+            },
+            {
+              "slot": 2,
+              "gen": 3,
+              "pid": 3086,
+              "rss_kb": 58672
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:27:49+00:00",
+          "elapsed_s": 137.7,
+          "FAILED": 220,
+          "READY": 12,
+          "RUNNING": 7,
+          "SUCCESSFUL": 3883,
+          "overdue_running": 0,
+          "ledger_rows": 9536,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 2868,
+              "rss_kb": 59312
+            },
+            {
+              "slot": 2,
+              "gen": 3,
+              "pid": 3086,
+              "rss_kb": 58720
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:27:54+00:00",
+          "elapsed_s": 142.8,
+          "FAILED": 227,
+          "READY": 12,
+          "RUNNING": 9,
+          "SUCCESSFUL": 4027,
+          "overdue_running": 0,
+          "ledger_rows": 9886,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 2868,
+              "rss_kb": 59328
+            },
+            {
+              "slot": 2,
+              "gen": 3,
+              "pid": 3086,
+              "rss_kb": 58800
+            },
+            {
+              "slot": 1,
+              "gen": 2,
+              "pid": 3269,
+              "rss_kb": 57712
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:27:59+00:00",
+          "elapsed_s": 147.9,
+          "FAILED": 233,
+          "READY": 12,
+          "RUNNING": 5,
+          "SUCCESSFUL": 4178,
+          "overdue_running": 0,
+          "ledger_rows": 10233,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 2868,
+              "rss_kb": 59344
+            },
+            {
+              "slot": 2,
+              "gen": 3,
+              "pid": 3086,
+              "rss_kb": 58848
+            },
+            {
+              "slot": 1,
+              "gen": 2,
+              "pid": 3269,
+              "rss_kb": 58368
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:28:04+00:00",
+          "elapsed_s": 153.0,
+          "RUNNING": 8,
+          "FAILED": 242,
+          "SUCCESSFUL": 4315,
+          "READY": 16,
+          "overdue_running": 0,
+          "ledger_rows": 10584,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 2868,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 2,
+              "gen": 3,
+              "pid": 3086,
+              "rss_kb": 58896
+            },
+            {
+              "slot": 1,
+              "gen": 2,
+              "pid": 3269,
+              "rss_kb": 58496
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:28:09+00:00",
+          "elapsed_s": 158.1,
+          "RUNNING": 6,
+          "FAILED": 250,
+          "SUCCESSFUL": 4461,
+          "READY": 17,
+          "overdue_running": 0,
+          "ledger_rows": 10947,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 2868,
+              "rss_kb": 59392
+            },
+            {
+              "slot": 2,
+              "gen": 3,
+              "pid": 3086,
+              "rss_kb": 58944
+            },
+            {
+              "slot": 1,
+              "gen": 2,
+              "pid": 3269,
+              "rss_kb": 58544
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:28:14+00:00",
+          "elapsed_s": 163.2,
+          "FAILED": 259,
+          "READY": 20,
+          "RUNNING": 6,
+          "SUCCESSFUL": 4602,
+          "overdue_running": 0,
+          "ledger_rows": 11295,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 2868,
+              "rss_kb": 59424
+            },
+            {
+              "slot": 2,
+              "gen": 3,
+              "pid": 3086,
+              "rss_kb": 58960
+            },
+            {
+              "slot": 1,
+              "gen": 2,
+              "pid": 3269,
+              "rss_kb": 58608
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:28:19+00:00",
+          "elapsed_s": 168.3,
+          "FAILED": 268,
+          "READY": 12,
+          "RUNNING": 6,
+          "SUCCESSFUL": 4754,
+          "overdue_running": 0,
+          "ledger_rows": 11657,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 2868,
+              "rss_kb": 59424
+            },
+            {
+              "slot": 2,
+              "gen": 3,
+              "pid": 3086,
+              "rss_kb": 58976
+            },
+            {
+              "slot": 1,
+              "gen": 2,
+              "pid": 3269,
+              "rss_kb": 58656
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:28:24+00:00",
+          "elapsed_s": 173.4,
+          "FAILED": 278,
+          "READY": 11,
+          "RUNNING": 7,
+          "SUCCESSFUL": 4897,
+          "overdue_running": 0,
+          "ledger_rows": 12004,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 3,
+              "pid": 3086,
+              "rss_kb": 59008
+            },
+            {
+              "slot": 1,
+              "gen": 2,
+              "pid": 3269,
+              "rss_kb": 58752
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:28:29+00:00",
+          "elapsed_s": 178.5,
+          "FAILED": 282,
+          "READY": 17,
+          "RUNNING": 9,
+          "SUCCESSFUL": 5038,
+          "overdue_running": 0,
+          "ledger_rows": 12363,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 3,
+              "pid": 3086,
+              "rss_kb": 59040
+            },
+            {
+              "slot": 1,
+              "gen": 2,
+              "pid": 3269,
+              "rss_kb": 58832
+            },
+            {
+              "slot": 0,
+              "gen": 3,
+              "pid": 3439,
+              "rss_kb": 58192
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:28:34+00:00",
+          "elapsed_s": 183.6,
+          "FAILED": 292,
+          "READY": 12,
+          "RUNNING": 7,
+          "SUCCESSFUL": 5188,
+          "overdue_running": 0,
+          "ledger_rows": 12737,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 3,
+              "pid": 3086,
+              "rss_kb": 59072
+            },
+            {
+              "slot": 1,
+              "gen": 2,
+              "pid": 3269,
+              "rss_kb": 58880
+            },
+            {
+              "slot": 0,
+              "gen": 3,
+              "pid": 3439,
+              "rss_kb": 58368
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:28:40+00:00",
+          "elapsed_s": 188.7,
+          "FAILED": 299,
+          "READY": 15,
+          "RUNNING": 6,
+          "SUCCESSFUL": 5332,
+          "overdue_running": 0,
+          "ledger_rows": 13091,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 3,
+              "pid": 3086,
+              "rss_kb": 59088
+            },
+            {
+              "slot": 1,
+              "gen": 2,
+              "pid": 3269,
+              "rss_kb": 58960
+            },
+            {
+              "slot": 0,
+              "gen": 3,
+              "pid": 3439,
+              "rss_kb": 58480
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:28:45+00:00",
+          "elapsed_s": 193.8,
+          "FAILED": 307,
+          "READY": 16,
+          "RUNNING": 7,
+          "SUCCESSFUL": 5475,
+          "overdue_running": 0,
+          "ledger_rows": 13452,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 3,
+              "pid": 3086,
+              "rss_kb": 59088
+            },
+            {
+              "slot": 0,
+              "gen": 3,
+              "pid": 3439,
+              "rss_kb": 58560
+            },
+            {
+              "slot": 1,
+              "gen": 3,
+              "pid": 3551,
+              "rss_kb": 11008
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:28:50+00:00",
+          "elapsed_s": 198.9,
+          "FAILED": 315,
+          "READY": 9,
+          "RUNNING": 5,
+          "SUCCESSFUL": 5629,
+          "overdue_running": 0,
+          "ledger_rows": 13812,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 3,
+              "pid": 3086,
+              "rss_kb": 59168
+            },
+            {
+              "slot": 0,
+              "gen": 3,
+              "pid": 3439,
+              "rss_kb": 58608
+            },
+            {
+              "slot": 1,
+              "gen": 3,
+              "pid": 3551,
+              "rss_kb": 58336
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:28:55+00:00",
+          "elapsed_s": 204.0,
+          "FAILED": 322,
+          "READY": 12,
+          "RUNNING": 8,
+          "SUCCESSFUL": 5769,
+          "overdue_running": 0,
+          "ledger_rows": 14157,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 3,
+              "pid": 3086,
+              "rss_kb": 59168
+            },
+            {
+              "slot": 0,
+              "gen": 3,
+              "pid": 3439,
+              "rss_kb": 58656
+            },
+            {
+              "slot": 1,
+              "gen": 3,
+              "pid": 3551,
+              "rss_kb": 58448
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:29:00+00:00",
+          "elapsed_s": 209.1,
+          "FAILED": 331,
+          "READY": 12,
+          "RUNNING": 6,
+          "SUCCESSFUL": 5915,
+          "overdue_running": 0,
+          "ledger_rows": 14524,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 3,
+              "pid": 3086,
+              "rss_kb": 59168
+            },
+            {
+              "slot": 0,
+              "gen": 3,
+              "pid": 3439,
+              "rss_kb": 58688
+            },
+            {
+              "slot": 1,
+              "gen": 3,
+              "pid": 3551,
+              "rss_kb": 58608
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:29:05+00:00",
+          "elapsed_s": 214.2,
+          "FAILED": 339,
+          "READY": 13,
+          "RUNNING": 1,
+          "SUCCESSFUL": 6064,
+          "overdue_running": 0,
+          "ledger_rows": 14871,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 3,
+              "pid": 3086,
+              "rss_kb": 59184
+            },
+            {
+              "slot": 0,
+              "gen": 3,
+              "pid": 3439,
+              "rss_kb": 58752
+            },
+            {
+              "slot": 1,
+              "gen": 3,
+              "pid": 3551,
+              "rss_kb": 58688
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:29:10+00:00",
+          "elapsed_s": 219.3,
+          "FAILED": 345,
+          "READY": 19,
+          "RUNNING": 4,
+          "SUCCESSFUL": 6202,
+          "overdue_running": 0,
+          "ledger_rows": 15220,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 3,
+              "pid": 3086,
+              "rss_kb": 59184
+            },
+            {
+              "slot": 0,
+              "gen": 3,
+              "pid": 3439,
+              "rss_kb": 58800
+            },
+            {
+              "slot": 1,
+              "gen": 3,
+              "pid": 3551,
+              "rss_kb": 58736
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:29:15+00:00",
+          "elapsed_s": 224.4,
+          "FAILED": 356,
+          "READY": 11,
+          "RUNNING": 8,
+          "SUCCESSFUL": 6348,
+          "overdue_running": 0,
+          "ledger_rows": 15578,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 3,
+              "pid": 3439,
+              "rss_kb": 58880
+            },
+            {
+              "slot": 1,
+              "gen": 3,
+              "pid": 3551,
+              "rss_kb": 58800
+            },
+            {
+              "slot": 2,
+              "gen": 4,
+              "pid": 3721,
+              "rss_kb": 10800
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:29:20+00:00",
+          "elapsed_s": 229.5,
+          "FAILED": 365,
+          "READY": 7,
+          "RUNNING": 11,
+          "SUCCESSFUL": 6496,
+          "overdue_running": 0,
+          "ledger_rows": 15921,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 3,
+              "pid": 3439,
+              "rss_kb": 58944
+            },
+            {
+              "slot": 1,
+              "gen": 3,
+              "pid": 3551,
+              "rss_kb": 58848
+            },
+            {
+              "slot": 2,
+              "gen": 4,
+              "pid": 3721,
+              "rss_kb": 58336
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:29:26+00:00",
+          "elapsed_s": 234.6,
+          "FAILED": 371,
+          "READY": 9,
+          "RUNNING": 12,
+          "SUCCESSFUL": 6637,
+          "overdue_running": 0,
+          "ledger_rows": 16259,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 3,
+              "pid": 3439,
+              "rss_kb": 59008
+            },
+            {
+              "slot": 1,
+              "gen": 3,
+              "pid": 3551,
+              "rss_kb": 58864
+            },
+            {
+              "slot": 2,
+              "gen": 4,
+              "pid": 3721,
+              "rss_kb": 58432
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:29:31+00:00",
+          "elapsed_s": 239.7,
+          "FAILED": 380,
+          "READY": 9,
+          "RUNNING": 7,
+          "SUCCESSFUL": 6789,
+          "overdue_running": 0,
+          "ledger_rows": 16610,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 3,
+              "pid": 3439,
+              "rss_kb": 59040
+            },
+            {
+              "slot": 1,
+              "gen": 3,
+              "pid": 3551,
+              "rss_kb": 58928
+            },
+            {
+              "slot": 2,
+              "gen": 4,
+              "pid": 3721,
+              "rss_kb": 58560
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:29:36+00:00",
+          "elapsed_s": 244.8,
+          "FAILED": 386,
+          "READY": 12,
+          "RUNNING": 8,
+          "SUCCESSFUL": 6931,
+          "overdue_running": 0,
+          "ledger_rows": 16950,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 3,
+              "pid": 3439,
+              "rss_kb": 59072
+            },
+            {
+              "slot": 1,
+              "gen": 3,
+              "pid": 3551,
+              "rss_kb": 58976
+            },
+            {
+              "slot": 2,
+              "gen": 4,
+              "pid": 3721,
+              "rss_kb": 58608
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:29:41+00:00",
+          "elapsed_s": 249.9,
+          "FAILED": 393,
+          "READY": 21,
+          "RUNNING": 6,
+          "SUCCESSFUL": 7071,
+          "overdue_running": 0,
+          "ledger_rows": 17307,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 3,
+              "pid": 3551,
+              "rss_kb": 59024
+            },
+            {
+              "slot": 2,
+              "gen": 4,
+              "pid": 3721,
+              "rss_kb": 58656
+            },
+            {
+              "slot": 0,
+              "gen": 4,
+              "pid": 3815,
+              "rss_kb": 58128
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:29:46+00:00",
+          "elapsed_s": 255.0,
+          "FAILED": 406,
+          "READY": 18,
+          "RUNNING": 11,
+          "SUCCESSFUL": 7209,
+          "overdue_running": 0,
+          "ledger_rows": 17664,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 3,
+              "pid": 3551,
+              "rss_kb": 59072
+            },
+            {
+              "slot": 2,
+              "gen": 4,
+              "pid": 3721,
+              "rss_kb": 58736
+            },
+            {
+              "slot": 0,
+              "gen": 4,
+              "pid": 3815,
+              "rss_kb": 58320
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:29:51+00:00",
+          "elapsed_s": 260.1,
+          "FAILED": 417,
+          "READY": 18,
+          "RUNNING": 8,
+          "SUCCESSFUL": 7354,
+          "overdue_running": 0,
+          "ledger_rows": 18031,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 3,
+              "pid": 3551,
+              "rss_kb": 59120
+            },
+            {
+              "slot": 2,
+              "gen": 4,
+              "pid": 3721,
+              "rss_kb": 58768
+            },
+            {
+              "slot": 0,
+              "gen": 4,
+              "pid": 3815,
+              "rss_kb": 58432
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:29:56+00:00",
+          "elapsed_s": 265.3,
+          "FAILED": 421,
+          "READY": 22,
+          "RUNNING": 6,
+          "SUCCESSFUL": 7501,
+          "overdue_running": 0,
+          "ledger_rows": 18411,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 3,
+              "pid": 3551,
+              "rss_kb": 59136
+            },
+            {
+              "slot": 2,
+              "gen": 4,
+              "pid": 3721,
+              "rss_kb": 58848
+            },
+            {
+              "slot": 0,
+              "gen": 4,
+              "pid": 3815,
+              "rss_kb": 58528
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:30:01+00:00",
+          "elapsed_s": 270.3,
+          "FAILED": 438,
+          "READY": 15,
+          "RUNNING": 1,
+          "SUCCESSFUL": 7649,
+          "overdue_running": 0,
+          "ledger_rows": 18789,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 3,
+              "pid": 3551,
+              "rss_kb": 59168
+            },
+            {
+              "slot": 2,
+              "gen": 4,
+              "pid": 3721,
+              "rss_kb": 58912
+            },
+            {
+              "slot": 0,
+              "gen": 4,
+              "pid": 3815,
+              "rss_kb": 58592
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:30:06+00:00",
+          "elapsed_s": 275.4,
+          "FAILED": 446,
+          "READY": 15,
+          "RUNNING": 4,
+          "SUCCESSFUL": 7791,
+          "overdue_running": 0,
+          "ledger_rows": 19140,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 3,
+              "pid": 3551,
+              "rss_kb": 59232
+            },
+            {
+              "slot": 2,
+              "gen": 4,
+              "pid": 3721,
+              "rss_kb": 58944
+            },
+            {
+              "slot": 0,
+              "gen": 4,
+              "pid": 3815,
+              "rss_kb": 58624
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:30:11+00:00",
+          "elapsed_s": 280.5,
+          "FAILED": 453,
+          "READY": 10,
+          "RUNNING": 9,
+          "SUCCESSFUL": 7937,
+          "overdue_running": 0,
+          "ledger_rows": 19492,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 3,
+              "pid": 3551,
+              "rss_kb": 59264
+            },
+            {
+              "slot": 2,
+              "gen": 4,
+              "pid": 3721,
+              "rss_kb": 59024
+            },
+            {
+              "slot": 0,
+              "gen": 4,
+              "pid": 3815,
+              "rss_kb": 58672
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:30:17+00:00",
+          "elapsed_s": 285.7,
+          "FAILED": 460,
+          "READY": 18,
+          "RUNNING": 7,
+          "SUCCESSFUL": 8077,
+          "overdue_running": 0,
+          "ledger_rows": 19845,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 3,
+              "pid": 3551,
+              "rss_kb": 59264
+            },
+            {
+              "slot": 2,
+              "gen": 4,
+              "pid": 3721,
+              "rss_kb": 59056
+            },
+            {
+              "slot": 0,
+              "gen": 4,
+              "pid": 3815,
+              "rss_kb": 58768
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:30:22+00:00",
+          "elapsed_s": 290.7,
+          "FAILED": 472,
+          "READY": 13,
+          "RUNNING": 8,
+          "SUCCESSFUL": 8222,
+          "overdue_running": 0,
+          "ledger_rows": 20218,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 3,
+              "pid": 3551,
+              "rss_kb": 59280
+            },
+            {
+              "slot": 2,
+              "gen": 4,
+              "pid": 3721,
+              "rss_kb": 59104
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:30:27+00:00",
+          "elapsed_s": 295.8,
+          "FAILED": 481,
+          "READY": 9,
+          "RUNNING": 1,
+          "SUCCESSFUL": 8377,
+          "overdue_running": 0,
+          "ledger_rows": 20567,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 3,
+              "pid": 3551,
+              "rss_kb": 59280
+            },
+            {
+              "slot": 2,
+              "gen": 4,
+              "pid": 3721,
+              "rss_kb": 59120
+            },
+            {
+              "slot": 0,
+              "gen": 5,
+              "pid": 3967,
+              "rss_kb": 58352
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:30:32+00:00",
+          "elapsed_s": 300.9,
+          "FAILED": 483,
+          "READY": 16,
+          "RUNNING": 5,
+          "SUCCESSFUL": 8517,
+          "overdue_running": 0,
+          "ledger_rows": 20901,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 3,
+              "pid": 3551,
+              "rss_kb": 59296
+            },
+            {
+              "slot": 2,
+              "gen": 4,
+              "pid": 3721,
+              "rss_kb": 59152
+            },
+            {
+              "slot": 0,
+              "gen": 5,
+              "pid": 3967,
+              "rss_kb": 58544
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:30:37+00:00",
+          "elapsed_s": 306.0,
+          "FAILED": 488,
+          "READY": 17,
+          "RUNNING": 3,
+          "SUCCESSFUL": 8666,
+          "overdue_running": 0,
+          "ledger_rows": 21251,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 3,
+              "pid": 3551,
+              "rss_kb": 59312
+            },
+            {
+              "slot": 2,
+              "gen": 4,
+              "pid": 3721,
+              "rss_kb": 59200
+            },
+            {
+              "slot": 0,
+              "gen": 5,
+              "pid": 3967,
+              "rss_kb": 58608
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:30:42+00:00",
+          "elapsed_s": 311.1,
+          "FAILED": 497,
+          "READY": 12,
+          "RUNNING": 8,
+          "SUCCESSFUL": 8810,
+          "overdue_running": 0,
+          "ledger_rows": 21606,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 3,
+              "pid": 3551,
+              "rss_kb": 59312
+            },
+            {
+              "slot": 2,
+              "gen": 4,
+              "pid": 3721,
+              "rss_kb": 59216
+            },
+            {
+              "slot": 0,
+              "gen": 5,
+              "pid": 3967,
+              "rss_kb": 58688
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:30:47+00:00",
+          "elapsed_s": 316.2,
+          "FAILED": 505,
+          "READY": 9,
+          "RUNNING": 7,
+          "SUCCESSFUL": 8959,
+          "overdue_running": 0,
+          "ledger_rows": 21960,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 3,
+              "pid": 3551,
+              "rss_kb": 59312
+            },
+            {
+              "slot": 2,
+              "gen": 4,
+              "pid": 3721,
+              "rss_kb": 59232
+            },
+            {
+              "slot": 0,
+              "gen": 5,
+              "pid": 3967,
+              "rss_kb": 58736
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:30:52+00:00",
+          "elapsed_s": 321.3,
+          "FAILED": 512,
+          "READY": 22,
+          "RUNNING": 3,
+          "SUCCESSFUL": 9096,
+          "overdue_running": 0,
+          "ledger_rows": 22309,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 3,
+              "pid": 3551,
+              "rss_kb": 59328
+            },
+            {
+              "slot": 0,
+              "gen": 5,
+              "pid": 3967,
+              "rss_kb": 58784
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:30:57+00:00",
+          "elapsed_s": 326.4,
+          "FAILED": 521,
+          "READY": 13,
+          "RUNNING": 4,
+          "SUCCESSFUL": 9248,
+          "overdue_running": 0,
+          "ledger_rows": 22670,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 3,
+              "pid": 3551,
+              "rss_kb": 59328
+            },
+            {
+              "slot": 0,
+              "gen": 5,
+              "pid": 3967,
+              "rss_kb": 58880
+            },
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 58256
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:31:02+00:00",
+          "elapsed_s": 331.5,
+          "FAILED": 526,
+          "READY": 15,
+          "RUNNING": 8,
+          "SUCCESSFUL": 9390,
+          "overdue_running": 0,
+          "ledger_rows": 23030,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 3,
+              "pid": 3551,
+              "rss_kb": 59344
+            },
+            {
+              "slot": 0,
+              "gen": 5,
+              "pid": 3967,
+              "rss_kb": 58928
+            },
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 58400
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:31:08+00:00",
+          "elapsed_s": 336.6,
+          "FAILED": 537,
+          "READY": 4,
+          "RUNNING": 7,
+          "SUCCESSFUL": 9541,
+          "overdue_running": 0,
+          "ledger_rows": 23377,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 3,
+              "pid": 3551,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 0,
+              "gen": 5,
+              "pid": 3967,
+              "rss_kb": 59008
+            },
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 58544
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:31:13+00:00",
+          "elapsed_s": 341.7,
+          "FAILED": 541,
+          "READY": 10,
+          "RUNNING": 5,
+          "SUCCESSFUL": 9687,
+          "overdue_running": 0,
+          "ledger_rows": 23721,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 3,
+              "pid": 3551,
+              "rss_kb": 59376
+            },
+            {
+              "slot": 0,
+              "gen": 5,
+              "pid": 3967,
+              "rss_kb": 59056
+            },
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 58576
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:31:18+00:00",
+          "elapsed_s": 346.8,
+          "FAILED": 547,
+          "READY": 11,
+          "RUNNING": 6,
+          "SUCCESSFUL": 9831,
+          "overdue_running": 0,
+          "ledger_rows": 24066,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 3,
+              "pid": 3551,
+              "rss_kb": 59392
+            },
+            {
+              "slot": 0,
+              "gen": 5,
+              "pid": 3967,
+              "rss_kb": 59088
+            },
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 58624
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:31:23+00:00",
+          "elapsed_s": 351.9,
+          "FAILED": 555,
+          "READY": 17,
+          "RUNNING": 3,
+          "SUCCESSFUL": 9973,
+          "overdue_running": 0,
+          "ledger_rows": 24421,
+          "rss": [
+            {
+              "slot": 1,
+              "gen": 3,
+              "pid": 3551,
+              "rss_kb": 59424
+            },
+            {
+              "slot": 0,
+              "gen": 5,
+              "pid": 3967,
+              "rss_kb": 59120
+            },
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 58672
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:31:28+00:00",
+          "elapsed_s": 357.0,
+          "FAILED": 567,
+          "READY": 12,
+          "RUNNING": 8,
+          "SUCCESSFUL": 10114,
+          "overdue_running": 0,
+          "ledger_rows": 24774,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 5,
+              "pid": 3967,
+              "rss_kb": 59152
+            },
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 58720
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:31:33+00:00",
+          "elapsed_s": 362.0,
+          "FAILED": 573,
+          "READY": 21,
+          "RUNNING": 4,
+          "SUCCESSFUL": 10256,
+          "overdue_running": 0,
+          "ledger_rows": 25132,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 5,
+              "pid": 3967,
+              "rss_kb": 59200
+            },
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 58816
+            },
+            {
+              "slot": 1,
+              "gen": 4,
+              "pid": 4449,
+              "rss_kb": 58304
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:31:38+00:00",
+          "elapsed_s": 367.2,
+          "FAILED": 583,
+          "READY": 21,
+          "RUNNING": 4,
+          "SUCCESSFUL": 10399,
+          "overdue_running": 0,
+          "ledger_rows": 25498,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 5,
+              "pid": 3967,
+              "rss_kb": 59232
+            },
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 58864
+            },
+            {
+              "slot": 1,
+              "gen": 4,
+              "pid": 4449,
+              "rss_kb": 58496
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:31:43+00:00",
+          "elapsed_s": 372.3,
+          "FAILED": 594,
+          "READY": 18,
+          "RUNNING": 9,
+          "SUCCESSFUL": 10539,
+          "overdue_running": 0,
+          "ledger_rows": 25878,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 5,
+              "pid": 3967,
+              "rss_kb": 59280
+            },
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 58944
+            },
+            {
+              "slot": 1,
+              "gen": 4,
+              "pid": 4449,
+              "rss_kb": 58592
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:31:48+00:00",
+          "elapsed_s": 377.4,
+          "FAILED": 607,
+          "READY": 11,
+          "RUNNING": 3,
+          "SUCCESSFUL": 10692,
+          "overdue_running": 0,
+          "ledger_rows": 26253,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 5,
+              "pid": 3967,
+              "rss_kb": 59296
+            },
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 58992
+            },
+            {
+              "slot": 1,
+              "gen": 4,
+              "pid": 4449,
+              "rss_kb": 58672
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:31:53+00:00",
+          "elapsed_s": 382.5,
+          "FAILED": 613,
+          "READY": 9,
+          "RUNNING": 7,
+          "SUCCESSFUL": 10837,
+          "overdue_running": 0,
+          "ledger_rows": 26592,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 5,
+              "pid": 3967,
+              "rss_kb": 59312
+            },
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 59008
+            },
+            {
+              "slot": 1,
+              "gen": 4,
+              "pid": 4449,
+              "rss_kb": 58752
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:31:58+00:00",
+          "elapsed_s": 387.6,
+          "FAILED": 617,
+          "READY": 16,
+          "RUNNING": 3,
+          "SUCCESSFUL": 10983,
+          "overdue_running": 0,
+          "ledger_rows": 26939,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 5,
+              "pid": 3967,
+              "rss_kb": 59328
+            },
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 59088
+            },
+            {
+              "slot": 1,
+              "gen": 4,
+              "pid": 4449,
+              "rss_kb": 58768
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:32:04+00:00",
+          "elapsed_s": 392.7,
+          "FAILED": 626,
+          "READY": 24,
+          "RUNNING": 4,
+          "SUCCESSFUL": 11118,
+          "overdue_running": 0,
+          "ledger_rows": 27299,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 59120
+            },
+            {
+              "slot": 1,
+              "gen": 4,
+              "pid": 4449,
+              "rss_kb": 58864
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:32:09+00:00",
+          "elapsed_s": 397.8,
+          "FAILED": 639,
+          "READY": 11,
+          "RUNNING": 6,
+          "SUCCESSFUL": 11269,
+          "overdue_running": 0,
+          "ledger_rows": 27679,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 59168
+            },
+            {
+              "slot": 1,
+              "gen": 4,
+              "pid": 4449,
+              "rss_kb": 58944
+            },
+            {
+              "slot": 0,
+              "gen": 6,
+              "pid": 4889,
+              "rss_kb": 57968
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:32:14+00:00",
+          "elapsed_s": 402.9,
+          "FAILED": 645,
+          "READY": 14,
+          "RUNNING": 5,
+          "SUCCESSFUL": 11414,
+          "overdue_running": 0,
+          "ledger_rows": 28026,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 59200
+            },
+            {
+              "slot": 1,
+              "gen": 4,
+              "pid": 4449,
+              "rss_kb": 58992
+            },
+            {
+              "slot": 0,
+              "gen": 6,
+              "pid": 4889,
+              "rss_kb": 58176
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:32:19+00:00",
+          "elapsed_s": 408.0,
+          "FAILED": 651,
+          "READY": 14,
+          "RUNNING": 4,
+          "SUCCESSFUL": 11562,
+          "overdue_running": 0,
+          "ledger_rows": 28366,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 59216
+            },
+            {
+              "slot": 1,
+              "gen": 4,
+              "pid": 4449,
+              "rss_kb": 59056
+            },
+            {
+              "slot": 0,
+              "gen": 6,
+              "pid": 4889,
+              "rss_kb": 58256
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:32:24+00:00",
+          "elapsed_s": 413.1,
+          "FAILED": 658,
+          "READY": 21,
+          "RUNNING": 5,
+          "SUCCESSFUL": 11703,
+          "overdue_running": 0,
+          "ledger_rows": 28717,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 59232
+            },
+            {
+              "slot": 1,
+              "gen": 4,
+              "pid": 4449,
+              "rss_kb": 59072
+            },
+            {
+              "slot": 0,
+              "gen": 6,
+              "pid": 4889,
+              "rss_kb": 58320
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:32:29+00:00",
+          "elapsed_s": 418.2,
+          "FAILED": 670,
+          "READY": 15,
+          "SUCCESSFUL": 11855,
+          "RUNNING": 0,
+          "overdue_running": 0,
+          "ledger_rows": 29088,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 59248
+            },
+            {
+              "slot": 1,
+              "gen": 4,
+              "pid": 4449,
+              "rss_kb": 59120
+            },
+            {
+              "slot": 0,
+              "gen": 6,
+              "pid": 4889,
+              "rss_kb": 58400
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:32:34+00:00",
+          "elapsed_s": 423.4,
+          "FAILED": 677,
+          "READY": 20,
+          "RUNNING": 3,
+          "SUCCESSFUL": 11993,
+          "overdue_running": 0,
+          "ledger_rows": 29443,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 59248
+            },
+            {
+              "slot": 1,
+              "gen": 4,
+              "pid": 4449,
+              "rss_kb": 59168
+            },
+            {
+              "slot": 0,
+              "gen": 6,
+              "pid": 4889,
+              "rss_kb": 58464
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:32:39+00:00",
+          "elapsed_s": 428.5,
+          "FAILED": 688,
+          "READY": 13,
+          "RUNNING": 4,
+          "SUCCESSFUL": 12141,
+          "overdue_running": 0,
+          "ledger_rows": 29808,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 59264
+            },
+            {
+              "slot": 1,
+              "gen": 4,
+              "pid": 4449,
+              "rss_kb": 59232
+            },
+            {
+              "slot": 0,
+              "gen": 6,
+              "pid": 4889,
+              "rss_kb": 58496
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:32:45+00:00",
+          "elapsed_s": 433.6,
+          "FAILED": 697,
+          "READY": 7,
+          "RUNNING": 6,
+          "SUCCESSFUL": 12289,
+          "overdue_running": 0,
+          "ledger_rows": 30153,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 59296
+            },
+            {
+              "slot": 0,
+              "gen": 6,
+              "pid": 4889,
+              "rss_kb": 58560
+            },
+            {
+              "slot": 1,
+              "gen": 5,
+              "pid": 5053,
+              "rss_kb": 56752
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:32:50+00:00",
+          "elapsed_s": 438.7,
+          "FAILED": 703,
+          "READY": 18,
+          "RUNNING": 8,
+          "SUCCESSFUL": 12423,
+          "overdue_running": 0,
+          "ledger_rows": 30500,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 59296
+            },
+            {
+              "slot": 0,
+              "gen": 6,
+              "pid": 4889,
+              "rss_kb": 58608
+            },
+            {
+              "slot": 1,
+              "gen": 5,
+              "pid": 5053,
+              "rss_kb": 58080
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:32:55+00:00",
+          "elapsed_s": 443.8,
+          "FAILED": 715,
+          "READY": 20,
+          "RUNNING": 7,
+          "SUCCESSFUL": 12566,
+          "overdue_running": 0,
+          "ledger_rows": 30863,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 59296
+            },
+            {
+              "slot": 0,
+              "gen": 6,
+              "pid": 4889,
+              "rss_kb": 58656
+            },
+            {
+              "slot": 1,
+              "gen": 5,
+              "pid": 5053,
+              "rss_kb": 58208
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:33:00+00:00",
+          "elapsed_s": 448.9,
+          "FAILED": 724,
+          "READY": 14,
+          "RUNNING": 6,
+          "SUCCESSFUL": 12717,
+          "overdue_running": 0,
+          "ledger_rows": 31233,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 59312
+            },
+            {
+              "slot": 0,
+              "gen": 6,
+              "pid": 4889,
+              "rss_kb": 58704
+            },
+            {
+              "slot": 1,
+              "gen": 5,
+              "pid": 5053,
+              "rss_kb": 58272
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:33:05+00:00",
+          "elapsed_s": 454.0,
+          "FAILED": 732,
+          "READY": 16,
+          "RUNNING": 3,
+          "SUCCESSFUL": 12863,
+          "overdue_running": 0,
+          "ledger_rows": 31579,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 59312
+            },
+            {
+              "slot": 0,
+              "gen": 6,
+              "pid": 4889,
+              "rss_kb": 58784
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:33:10+00:00",
+          "elapsed_s": 459.1,
+          "FAILED": 739,
+          "READY": 20,
+          "RUNNING": 10,
+          "SUCCESSFUL": 12998,
+          "overdue_running": 0,
+          "ledger_rows": 31926,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 59328
+            },
+            {
+              "slot": 0,
+              "gen": 6,
+              "pid": 4889,
+              "rss_kb": 58832
+            },
+            {
+              "slot": 1,
+              "gen": 6,
+              "pid": 5174,
+              "rss_kb": 58320
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:33:15+00:00",
+          "elapsed_s": 464.3,
+          "FAILED": 750,
+          "READY": 21,
+          "RUNNING": 5,
+          "SUCCESSFUL": 13144,
+          "overdue_running": 0,
+          "ledger_rows": 32298,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 59344
+            },
+            {
+              "slot": 0,
+              "gen": 6,
+              "pid": 4889,
+              "rss_kb": 58864
+            },
+            {
+              "slot": 1,
+              "gen": 6,
+              "pid": 5174,
+              "rss_kb": 58432
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:33:20+00:00",
+          "elapsed_s": 469.4,
+          "FAILED": 761,
+          "READY": 12,
+          "RUNNING": 7,
+          "SUCCESSFUL": 13293,
+          "overdue_running": 0,
+          "ledger_rows": 32664,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 59344
+            },
+            {
+              "slot": 0,
+              "gen": 6,
+              "pid": 4889,
+              "rss_kb": 58880
+            },
+            {
+              "slot": 1,
+              "gen": 6,
+              "pid": 5174,
+              "rss_kb": 58560
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:33:25+00:00",
+          "elapsed_s": 474.5,
+          "FAILED": 768,
+          "READY": 19,
+          "RUNNING": 5,
+          "SUCCESSFUL": 13434,
+          "overdue_running": 0,
+          "ledger_rows": 33022,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 59360
+            },
+            {
+              "slot": 0,
+              "gen": 6,
+              "pid": 4889,
+              "rss_kb": 58944
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:33:31+00:00",
+          "elapsed_s": 479.6,
+          "FAILED": 779,
+          "READY": 21,
+          "RUNNING": 3,
+          "SUCCESSFUL": 13579,
+          "overdue_running": 0,
+          "ledger_rows": 33383,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 59376
+            },
+            {
+              "slot": 0,
+              "gen": 6,
+              "pid": 4889,
+              "rss_kb": 59008
+            },
+            {
+              "slot": 1,
+              "gen": 7,
+              "pid": 5262,
+              "rss_kb": 58160
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:33:36+00:00",
+          "elapsed_s": 484.7,
+          "FAILED": 787,
+          "READY": 13,
+          "RUNNING": 10,
+          "SUCCESSFUL": 13725,
+          "overdue_running": 0,
+          "ledger_rows": 33738,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 59392
+            },
+            {
+              "slot": 0,
+              "gen": 6,
+              "pid": 4889,
+              "rss_kb": 59008
+            },
+            {
+              "slot": 1,
+              "gen": 7,
+              "pid": 5262,
+              "rss_kb": 58336
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:33:41+00:00",
+          "elapsed_s": 489.9,
+          "FAILED": 793,
+          "READY": 20,
+          "RUNNING": 6,
+          "SUCCESSFUL": 13869,
+          "overdue_running": 0,
+          "ledger_rows": 34089,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 59408
+            },
+            {
+              "slot": 0,
+              "gen": 6,
+              "pid": 4889,
+              "rss_kb": 59008
+            },
+            {
+              "slot": 1,
+              "gen": 7,
+              "pid": 5262,
+              "rss_kb": 58448
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:33:46+00:00",
+          "elapsed_s": 495.0,
+          "FAILED": 802,
+          "READY": 15,
+          "RUNNING": 3,
+          "SUCCESSFUL": 14021,
+          "overdue_running": 0,
+          "ledger_rows": 34451,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 59408
+            },
+            {
+              "slot": 0,
+              "gen": 6,
+              "pid": 4889,
+              "rss_kb": 59040
+            },
+            {
+              "slot": 1,
+              "gen": 7,
+              "pid": 5262,
+              "rss_kb": 58512
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:33:51+00:00",
+          "elapsed_s": 500.1,
+          "FAILED": 809,
+          "READY": 12,
+          "RUNNING": 6,
+          "SUCCESSFUL": 14167,
+          "overdue_running": 0,
+          "ledger_rows": 34796,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 59408
+            },
+            {
+              "slot": 0,
+              "gen": 6,
+              "pid": 4889,
+              "rss_kb": 59040
+            },
+            {
+              "slot": 1,
+              "gen": 7,
+              "pid": 5262,
+              "rss_kb": 58560
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:33:56+00:00",
+          "elapsed_s": 505.2,
+          "FAILED": 816,
+          "READY": 11,
+          "RUNNING": 5,
+          "SUCCESSFUL": 14318,
+          "overdue_running": 0,
+          "ledger_rows": 35146,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 59408
+            },
+            {
+              "slot": 0,
+              "gen": 6,
+              "pid": 4889,
+              "rss_kb": 59040
+            },
+            {
+              "slot": 1,
+              "gen": 7,
+              "pid": 5262,
+              "rss_kb": 58640
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:34:01+00:00",
+          "elapsed_s": 510.3,
+          "FAILED": 822,
+          "READY": 19,
+          "RUNNING": 3,
+          "SUCCESSFUL": 14459,
+          "overdue_running": 0,
+          "ledger_rows": 35478,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 59408
+            },
+            {
+              "slot": 0,
+              "gen": 6,
+              "pid": 4889,
+              "rss_kb": 59072
+            },
+            {
+              "slot": 1,
+              "gen": 7,
+              "pid": 5262,
+              "rss_kb": 58688
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:34:06+00:00",
+          "elapsed_s": 515.5,
+          "FAILED": 831,
+          "READY": 16,
+          "RUNNING": 7,
+          "SUCCESSFUL": 14602,
+          "overdue_running": 0,
+          "ledger_rows": 35834,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 59424
+            },
+            {
+              "slot": 0,
+              "gen": 6,
+              "pid": 4889,
+              "rss_kb": 59104
+            },
+            {
+              "slot": 1,
+              "gen": 8,
+              "pid": 5373,
+              "rss_kb": 12896
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:34:12+00:00",
+          "elapsed_s": 520.6,
+          "FAILED": 840,
+          "READY": 17,
+          "RUNNING": 5,
+          "SUCCESSFUL": 14747,
+          "overdue_running": 0,
+          "ledger_rows": 36210,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 59424
+            },
+            {
+              "slot": 0,
+              "gen": 6,
+              "pid": 4889,
+              "rss_kb": 59120
+            },
+            {
+              "slot": 1,
+              "gen": 8,
+              "pid": 5373,
+              "rss_kb": 58192
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:34:17+00:00",
+          "elapsed_s": 525.7,
+          "FAILED": 852,
+          "READY": 12,
+          "RUNNING": 5,
+          "SUCCESSFUL": 14893,
+          "overdue_running": 0,
+          "ledger_rows": 36579,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 59424
+            },
+            {
+              "slot": 0,
+              "gen": 6,
+              "pid": 4889,
+              "rss_kb": 59136
+            },
+            {
+              "slot": 1,
+              "gen": 8,
+              "pid": 5373,
+              "rss_kb": 58352
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:34:22+00:00",
+          "elapsed_s": 530.8,
+          "FAILED": 859,
+          "READY": 21,
+          "RUNNING": 2,
+          "SUCCESSFUL": 15033,
+          "overdue_running": 0,
+          "ledger_rows": 36932,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 59424
+            },
+            {
+              "slot": 0,
+              "gen": 6,
+              "pid": 4889,
+              "rss_kb": 59136
+            },
+            {
+              "slot": 1,
+              "gen": 8,
+              "pid": 5373,
+              "rss_kb": 58496
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:34:27+00:00",
+          "elapsed_s": 535.9,
+          "FAILED": 870,
+          "READY": 14,
+          "RUNNING": 12,
+          "SUCCESSFUL": 15172,
+          "overdue_running": 0,
+          "ledger_rows": 37280,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 59456
+            },
+            {
+              "slot": 0,
+              "gen": 6,
+              "pid": 4889,
+              "rss_kb": 59168
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:34:32+00:00",
+          "elapsed_s": 541.0,
+          "FAILED": 877,
+          "READY": 8,
+          "RUNNING": 5,
+          "SUCCESSFUL": 15310,
+          "overdue_running": 0,
+          "ledger_rows": 37605,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 59456
+            },
+            {
+              "slot": 0,
+              "gen": 6,
+              "pid": 4889,
+              "rss_kb": 59168
+            },
+            {
+              "slot": 1,
+              "gen": 9,
+              "pid": 5442,
+              "rss_kb": 58416
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:34:37+00:00",
+          "elapsed_s": 546.5,
+          "FAILED": 884,
+          "RUNNING": 4,
+          "SUCCESSFUL": 15312,
+          "READY": 0,
+          "overdue_running": 0,
+          "ledger_rows": 37628,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 59456
+            },
+            {
+              "slot": 0,
+              "gen": 6,
+              "pid": 4889,
+              "rss_kb": 59168
+            },
+            {
+              "slot": 1,
+              "gen": 9,
+              "pid": 5442,
+              "rss_kb": 58416
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:34:40+00:00",
+          "elapsed_s": 549.3,
+          "FAILED": 884,
+          "SUCCESSFUL": 15316,
+          "READY": 0,
+          "RUNNING": 0,
+          "overdue_running": 0,
+          "ledger_rows": 37636,
+          "rss": [
+            {
+              "slot": 2,
+              "gen": 5,
+              "pid": 4152,
+              "rss_kb": 59456
+            },
+            {
+              "slot": 0,
+              "gen": 6,
+              "pid": 4889,
+              "rss_kb": 59168
+            },
+            {
+              "slot": 1,
+              "gen": 9,
+              "pid": 5442,
+              "rss_kb": 58416
+            }
+          ]
+        }
+      ],
+      "analysis": {
+        "status_counts": {
+          "SUCCESSFUL": 15316,
+          "FAILED": 884
+        },
+        "per_type": {
+          "doomed": {
+            "FAILED": 884
+          },
+          "flaky_once": {
+            "SUCCESSFUL": 835
+          },
+          "medium": {
+            "SUCCESSFUL": 2373
+          },
+          "quick": {
+            "SUCCESSFUL": 11252
+          },
+          "slow": {
+            "SUCCESSFUL": 856
+          }
+        },
+        "enqueued_by_producers": 16200,
+        "task_rows": 16200,
+        "executions": 18832,
+        "ledger_rows": 37636,
+        "completions_histogram": {
+          "1": 15315,
+          "2": 1
+        },
+        "double_completed": [
+          {
+            "task_id": "c997a354-a137-4595-8689-fd68ccef53fa",
+            "type": "quick",
+            "completions": [
+              {
+                "at": "2026-09-01T13:27:49.084771+00:00",
+                "pid": 2607
+              },
+              {
+                "at": "2026-09-01T13:28:04.662262+00:00",
+                "pid": 3086
+              }
+            ]
+          }
+        ],
+        "interrupted_executions": 28,
+        "reclaim_delays_s": [
+          15.28,
+          15.34,
+          15.45,
+          15.57,
+          15.58,
+          15.79,
+          15.86,
+          15.86,
+          16.05,
+          16.32,
+          16.66,
+          16.67,
+          16.67,
+          16.73,
+          17.2,
+          17.36,
+          17.44,
+          17.78,
+          17.78,
+          18.72,
+          18.72,
+          18.93,
+          18.93,
+          18.93,
+          18.93,
+          19.08,
+          19.09,
+          19.47
+        ],
+        "reclaim_bound_s": 37.5,
+        "claim_window_missing_starts": 1,
+        "max_overdue_running": 0,
+        "max_ready_backlog": 24,
+        "latency_first_attempt": {
+          "all": {
+            "count": 14451,
+            "p50_s": 0.123,
+            "p95_s": 1.526,
+            "p99_s": 1.627,
+            "max_s": 1.744
+          },
+          "medium": {
+            "count": 2367,
+            "p50_s": 0.271,
+            "p95_s": 0.391,
+            "p99_s": 0.423,
+            "max_s": 0.596
+          },
+          "quick": {
+            "count": 11241,
+            "p50_s": 0.097,
+            "p95_s": 0.216,
+            "p99_s": 0.249,
+            "max_s": 0.425
+          },
+          "slow": {
+            "count": 843,
+            "p50_s": 1.565,
+            "p95_s": 1.679,
+            "p99_s": 1.712,
+            "max_s": 1.744
+          }
+        },
+        "assertions": [
+          {
+            "assertion": "every enqueued task has a row",
+            "passed": true,
+            "observed": "producers reported 16200, table has 16200"
+          },
+          {
+            "assertion": "all tasks terminal after drain",
+            "passed": true,
+            "observed": "drained=True, non-terminal rows=0"
+          },
+          {
+            "assertion": "no lock older than 27.5s in any live sample",
+            "passed": true,
+            "observed": "max overdue RUNNING rows across 109 samples: 0"
+          },
+          {
+            "assertion": "attempts never exceed max_attempts",
+            "passed": true,
+            "observed": "violations: 0"
+          },
+          {
+            "assertion": "attempts == len(worker_ids) on every row",
+            "passed": true,
+            "observed": "violations: 0"
+          },
+          {
+            "assertion": "every SUCCESSFUL task has >= 1 ledger completion",
+            "passed": true,
+            "observed": "phantom successes: 0"
+          },
+          {
+            "assertion": "double completions only from killed workers",
+            "passed": true,
+            "observed": "double-completed tasks: 1, unattributed to a kill: 0"
+          },
+          {
+            "assertion": "interrupted executions re-executed or abandoned",
+            "passed": true,
+            "observed": "interrupted: 28, re-executed: 28, abandoned: 0, unresolved: 0"
+          },
+          {
+            "assertion": "re-execution within 37.5s of interrupted start",
+            "passed": true,
+            "observed": "max delay 19.5s over 28 reclaims"
+          },
+          {
+            "assertion": "all doomed tasks FAILED with attempts == max_attempts",
+            "passed": true,
+            "observed": "doomed: 884, failed: 884"
+          },
+          {
+            "assertion": "no organic failures outside doomed",
+            "passed": true,
+            "observed": "unexplained FAILED rows: 0, flaky_once FAILED (chaos-consumed attempts): 0"
+          },
+          {
+            "assertion": "no unexpected worker exits",
+            "passed": true,
+            "observed": "unexpected exits: 0"
+          }
+        ]
+      }
+    },
+    {
+      "config": {
+        "name": "crash-window",
+        "kind": "crash_window",
+        "tasks": 4,
+        "hold_seconds": 8.0,
+        "concurrency": 2,
+        "restart_delay": 3.0,
+        "timeout": 150.0
+      },
+      "seed": 350589,
+      "started_at": "2026-09-01T13:34:41+00:00",
+      "load_seconds": 28.2,
+      "wall_seconds": 28.2,
+      "kills": 1,
+      "drained": true,
+      "running_at_kill": 2,
+      "producers": [
+        {
+          "enqueued": 4,
+          "by_type": {
+            "slow_hold": 4
+          },
+          "returncode": 0
+        }
+      ],
+      "events": [
+        {
+          "at": "2026-09-01T13:34:41+00:00",
+          "event": "worker_started",
+          "slot": 0,
+          "gen": 1,
+          "pid": 5478
+        },
+        {
+          "at": "2026-09-01T13:34:42+00:00",
+          "event": "worker_killed",
+          "slot": 0,
+          "gen": 1,
+          "pid": 5478
+        },
+        {
+          "at": "2026-09-01T13:34:45+00:00",
+          "event": "worker_started",
+          "slot": 0,
+          "gen": 2,
+          "pid": 5498
+        },
+        {
+          "at": "2026-09-01T13:35:09+00:00",
+          "event": "worker_stopping",
+          "slot": 0,
+          "gen": 2,
+          "pid": 5498
+        }
+      ],
+      "rss": [
+        {
+          "slot": 0,
+          "gen": 1,
+          "samples": 1,
+          "first_kb": 57168,
+          "last_kb": 57168,
+          "max_kb": 57168,
+          "first_at_s": 1.0,
+          "last_at_s": 1.0
+        },
+        {
+          "slot": 0,
+          "gen": 2,
+          "samples": 13,
+          "first_kb": 10864,
+          "last_kb": 57440,
+          "max_kb": 57440,
+          "first_at_s": 4.1,
+          "last_at_s": 27.9
+        }
+      ],
+      "samples": [
+        {
+          "t": "2026-09-01T13:34:42+00:00",
+          "elapsed_s": 1.0,
+          "RUNNING": 2,
+          "READY": 2,
+          "SUCCESSFUL": 0,
+          "FAILED": 0,
+          "overdue_running": 0,
+          "ledger_rows": 2,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 1,
+              "pid": 5478,
+              "rss_kb": 57168
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:34:45+00:00",
+          "elapsed_s": 4.1,
+          "RUNNING": 2,
+          "READY": 2,
+          "SUCCESSFUL": 0,
+          "FAILED": 0,
+          "overdue_running": 0,
+          "ledger_rows": 2,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 5498,
+              "rss_kb": 10864
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:34:47+00:00",
+          "elapsed_s": 6.2,
+          "RUNNING": 4,
+          "READY": 0,
+          "SUCCESSFUL": 0,
+          "FAILED": 0,
+          "overdue_running": 0,
+          "ledger_rows": 4,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 5498,
+              "rss_kb": 57184
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:34:49+00:00",
+          "elapsed_s": 8.4,
+          "RUNNING": 4,
+          "READY": 0,
+          "SUCCESSFUL": 0,
+          "FAILED": 0,
+          "overdue_running": 0,
+          "ledger_rows": 4,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 5498,
+              "rss_kb": 57184
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:34:51+00:00",
+          "elapsed_s": 10.6,
+          "RUNNING": 4,
+          "READY": 0,
+          "SUCCESSFUL": 0,
+          "FAILED": 0,
+          "overdue_running": 0,
+          "ledger_rows": 4,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 5498,
+              "rss_kb": 57248
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:34:54+00:00",
+          "elapsed_s": 12.7,
+          "SUCCESSFUL": 2,
+          "RUNNING": 2,
+          "READY": 0,
+          "FAILED": 0,
+          "overdue_running": 0,
+          "ledger_rows": 6,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 5498,
+              "rss_kb": 57280
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:34:56+00:00",
+          "elapsed_s": 14.9,
+          "SUCCESSFUL": 2,
+          "RUNNING": 2,
+          "READY": 0,
+          "FAILED": 0,
+          "overdue_running": 0,
+          "ledger_rows": 6,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 5498,
+              "rss_kb": 57328
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:34:58+00:00",
+          "elapsed_s": 17.0,
+          "SUCCESSFUL": 2,
+          "RUNNING": 2,
+          "READY": 0,
+          "FAILED": 0,
+          "overdue_running": 0,
+          "ledger_rows": 6,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 5498,
+              "rss_kb": 57392
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:35:00+00:00",
+          "elapsed_s": 19.2,
+          "SUCCESSFUL": 2,
+          "RUNNING": 2,
+          "READY": 0,
+          "FAILED": 0,
+          "overdue_running": 0,
+          "ledger_rows": 6,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 5498,
+              "rss_kb": 57392
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:35:02+00:00",
+          "elapsed_s": 21.3,
+          "SUCCESSFUL": 2,
+          "RUNNING": 2,
+          "READY": 0,
+          "FAILED": 0,
+          "overdue_running": 0,
+          "ledger_rows": 8,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 5498,
+              "rss_kb": 57424
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:35:04+00:00",
+          "elapsed_s": 23.5,
+          "SUCCESSFUL": 2,
+          "RUNNING": 2,
+          "READY": 0,
+          "FAILED": 0,
+          "overdue_running": 0,
+          "ledger_rows": 8,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 5498,
+              "rss_kb": 57424
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:35:06+00:00",
+          "elapsed_s": 25.7,
+          "SUCCESSFUL": 2,
+          "RUNNING": 2,
+          "READY": 0,
+          "FAILED": 0,
+          "overdue_running": 0,
+          "ledger_rows": 8,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 5498,
+              "rss_kb": 57424
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:35:09+00:00",
+          "elapsed_s": 27.8,
+          "SUCCESSFUL": 4,
+          "READY": 0,
+          "RUNNING": 0,
+          "FAILED": 0,
+          "overdue_running": 0,
+          "ledger_rows": 10,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 5498,
+              "rss_kb": 57440
+            }
+          ]
+        },
+        {
+          "t": "2026-09-01T13:35:09+00:00",
+          "elapsed_s": 27.9,
+          "SUCCESSFUL": 4,
+          "READY": 0,
+          "RUNNING": 0,
+          "FAILED": 0,
+          "overdue_running": 0,
+          "ledger_rows": 10,
+          "rss": [
+            {
+              "slot": 0,
+              "gen": 2,
+              "pid": 5498,
+              "rss_kb": 57440
+            }
+          ]
+        }
+      ],
+      "analysis": {
+        "status_counts": {
+          "SUCCESSFUL": 4
+        },
+        "per_type": {
+          "slow_hold": {
+            "SUCCESSFUL": 4
+          }
+        },
+        "enqueued_by_producers": 4,
+        "task_rows": 4,
+        "executions": 6,
+        "ledger_rows": 10,
+        "completions_histogram": {
+          "1": 4
+        },
+        "double_completed": [],
+        "interrupted_executions": 2,
+        "reclaim_delays_s": [
+          19.72,
+          19.72
+        ],
+        "reclaim_bound_s": 37.5,
+        "claim_window_missing_starts": 0,
+        "max_overdue_running": 0,
+        "max_ready_backlog": 2,
+        "latency_first_attempt": {
+          "all": {
+            "count": 2,
+            "p50_s": 12.395,
+            "p95_s": 12.395,
+            "p99_s": 12.395,
+            "max_s": 12.395
+          },
+          "slow_hold": {
+            "count": 2,
+            "p50_s": 12.395,
+            "p95_s": 12.395,
+            "p99_s": 12.395,
+            "max_s": 12.395
+          }
+        },
+        "assertions": [
+          {
+            "assertion": "every enqueued task has a row",
+            "passed": true,
+            "observed": "producers reported 4, table has 4"
+          },
+          {
+            "assertion": "all tasks terminal after drain",
+            "passed": true,
+            "observed": "drained=True, non-terminal rows=0"
+          },
+          {
+            "assertion": "no lock older than 27.5s in any live sample",
+            "passed": true,
+            "observed": "max overdue RUNNING rows across 14 samples: 0"
+          },
+          {
+            "assertion": "attempts never exceed max_attempts",
+            "passed": true,
+            "observed": "violations: 0"
+          },
+          {
+            "assertion": "attempts == len(worker_ids) on every row",
+            "passed": true,
+            "observed": "violations: 0"
+          },
+          {
+            "assertion": "every SUCCESSFUL task has >= 1 ledger completion",
+            "passed": true,
+            "observed": "phantom successes: 0"
+          },
+          {
+            "assertion": "double completions only from killed workers",
+            "passed": true,
+            "observed": "double-completed tasks: 0, unattributed to a kill: 0"
+          },
+          {
+            "assertion": "interrupted executions re-executed or abandoned",
+            "passed": true,
+            "observed": "interrupted: 2, re-executed: 2, abandoned: 0, unresolved: 0"
+          },
+          {
+            "assertion": "re-execution within 37.5s of interrupted start",
+            "passed": true,
+            "observed": "max delay 19.7s over 2 reclaims"
+          },
+          {
+            "assertion": "kill interrupted the expected number of in-flight tasks",
+            "passed": true,
+            "observed": "expected 2, observed 2"
+          },
+          {
+            "assertion": "all doomed tasks FAILED with attempts == max_attempts",
+            "passed": true,
+            "observed": "doomed: 0, failed: 0"
+          },
+          {
+            "assertion": "no organic failures outside doomed",
+            "passed": true,
+            "observed": "unexplained FAILED rows: 0, flaky_once FAILED (chaos-consumed attempts): 0"
+          },
+          {
+            "assertion": "no unexpected worker exits",
+            "passed": true,
+            "observed": "unexpected exits: 0"
+          }
+        ]
+      }
+    }
+  ],
+  "total_load_seconds": 1289.0,
+  "total_wall_seconds": 1304.0,
+  "finished_at": "2026-09-01T13:35:09+00:00"
+}

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -76,19 +76,30 @@ than a changed claim.
 ## Reliability under load
 
 Speed is not the product claim; the durability construction is. A
-separate soak and chaos harness ran django-ox 0.1.0 for 21.5 minutes of
-sustained mixed load on PostgreSQL 16: 37,802 tasks across three
+separate soak and chaos harness ran django-ox 0.3.1 for 21.5 minutes of
+sustained mixed load on PostgreSQL 16: 37,804 tasks across three
 scenarios, including 9 minutes in which a random worker was SIGKILLed
-every 20 to 45 seconds (16 kills total, 39 interrupted claims). Every
-task reached a terminal state, every interrupted claim was reclaimed and
-re-executed inside the documented bound, retry counts stayed bounded on
-every row, and zero tasks were lost or double-completed. Latency under
-kill-chaos was within noise of the undisturbed baseline (p50 0.217 s vs
-0.211 s).
+every 20 to 45 seconds (18 kills total, 30 interrupted executions).
+Thirty-seven assertions ran and all thirty-seven passed. Every task
+reached a terminal state, every interrupted execution was re-executed
+inside the documented bound (slowest reclaim 19.7 s against a bound of
+37.5 s), and retry counts stayed bounded on every row.
+
+One task executed twice, in the chaos scenario, after its worker was
+killed between finishing the task and recording the outcome. That is what
+at-least-once execution means, and it is the reason the harness asks
+whether a second execution is attributable to a kill rather than whether
+one happened: across 37,804 tasks, zero double executions could not be
+traced to a kill, and no task ran twice without one.
+
+Latency under kill-chaos was within a millisecond of the undisturbed
+baseline at the median (p50 0.123 s against 0.122 s).
 
 The full report, including the harness design, every assertion, and the
 caveats, is in
-[`benchmarks/SOAK-2026-08-16.md`](https://github.com/oxpull/django-ox/blob/main/benchmarks/SOAK-2026-08-16.md).
+[`benchmarks/SOAK-2026-09-01.md`](https://github.com/oxpull/django-ox/blob/main/benchmarks/SOAK-2026-09-01.md).
+The [previous run](https://github.com/oxpull/django-ox/blob/main/benchmarks/SOAK-2026-08-16.md)
+measured 0.1.0, which predates the lease fencing added in 0.2.0.
 
 ## What to take from this
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2285,19 +2285,30 @@ than a changed claim.
 ## Reliability under load
 
 Speed is not the product claim; the durability construction is. A
-separate soak and chaos harness ran django-ox 0.1.0 for 21.5 minutes of
-sustained mixed load on PostgreSQL 16: 37,802 tasks across three
+separate soak and chaos harness ran django-ox 0.3.1 for 21.5 minutes of
+sustained mixed load on PostgreSQL 16: 37,804 tasks across three
 scenarios, including 9 minutes in which a random worker was SIGKILLed
-every 20 to 45 seconds (16 kills total, 39 interrupted claims). Every
-task reached a terminal state, every interrupted claim was reclaimed and
-re-executed inside the documented bound, retry counts stayed bounded on
-every row, and zero tasks were lost or double-completed. Latency under
-kill-chaos was within noise of the undisturbed baseline (p50 0.217 s vs
-0.211 s).
+every 20 to 45 seconds (18 kills total, 30 interrupted executions).
+Thirty-seven assertions ran and all thirty-seven passed. Every task
+reached a terminal state, every interrupted execution was re-executed
+inside the documented bound (slowest reclaim 19.7 s against a bound of
+37.5 s), and retry counts stayed bounded on every row.
+
+One task executed twice, in the chaos scenario, after its worker was
+killed between finishing the task and recording the outcome. That is what
+at-least-once execution means, and it is the reason the harness asks
+whether a second execution is attributable to a kill rather than whether
+one happened: across 37,804 tasks, zero double executions could not be
+traced to a kill, and no task ran twice without one.
+
+Latency under kill-chaos was within a millisecond of the undisturbed
+baseline at the median (p50 0.123 s against 0.122 s).
 
 The full report, including the harness design, every assertion, and the
 caveats, is in
-[`benchmarks/SOAK-2026-08-16.md`](https://github.com/oxpull/django-ox/blob/main/benchmarks/SOAK-2026-08-16.md).
+[`benchmarks/SOAK-2026-09-01.md`](https://github.com/oxpull/django-ox/blob/main/benchmarks/SOAK-2026-09-01.md).
+The [previous run](https://github.com/oxpull/django-ox/blob/main/benchmarks/SOAK-2026-08-16.md)
+measured 0.1.0, which predates the lease fencing added in 0.2.0.
 
 ## What to take from this
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2471,7 +2471,8 @@ how to hear when it opens.
 
 Both run on the databases the free tier tests in CI: SQLite, PostgreSQL and
 MySQL 8. MariaDB 10.6+ takes the same claim path but is not part of the tested
-matrix. Batches are tested to 100,000 members in a single batch.
+matrix. Batches have been measured to 100,000 members in a single batch on
+SQLite and on PostgreSQL 16.
 
 ## What Pro is not
 

--- a/docs/pro.md
+++ b/docs/pro.md
@@ -24,7 +24,8 @@ how to hear when it opens.
 
 Both run on the databases the free tier tests in CI: SQLite, PostgreSQL and
 MySQL 8. MariaDB 10.6+ takes the same claim path but is not part of the tested
-matrix. Batches are tested to 100,000 members in a single batch.
+matrix. Batches have been measured to 100,000 members in a single batch on
+SQLite and on PostgreSQL 16.
 
 ## What Pro is not
 


### PR DESCRIPTION
Two published figures described a version other than the one on PyPI, and one of them claimed more than the product guarantees.

**The batch width figure.** The Pro page named SQLite, PostgreSQL and MySQL 8 in one sentence and gave the 100,000-member figure in the next. That sweep ran on SQLite and PostgreSQL 16 only. The figure now names the databases it came from.

**The reliability figures.** They were measured on 0.1.0, which predates the lease fencing added in 0.2.0. The harness has been re-run on 0.3.1: 37,804 tasks over 21.5 minutes on PostgreSQL 16, 18 kills, 30 interrupted executions, 37 assertions, all passing. Report in `benchmarks/SOAK-2026-09-01.md`, written from the raw JSON alongside it.

The earlier write-up said no task was lost or double-completed. The second half is stronger than the guarantee: execution is at-least-once, so a worker killed between finishing a task and recording the outcome leaves that task to run again, and one task in this run did. The page now reports what the harness actually asks, which is whether a second execution is attributable to a kill. None was unattributed across 37,804 tasks.

The README carries the result too. A queue is chosen on what it does when a worker dies, and the README described that only as a claim.