### PR TITLE
Release 0.4.0: a claim seam for Worker subclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.0] - 2026-09-01
 
 ### Added
 
 - `WORKER_CLASS` in a backend's `OPTIONS`: the dotted path of the `Worker`
   subclass `ox_worker` runs. Resolved from settings rather than from the
-  command line, so every child `ox_worker --processes N` starts runs the
-  same worker as the parent.
+  command line, so a worker chosen here is the worker in every child
+  process under `ox_worker --processes N`, not only in the parent.
 - `Worker.claim_filter_q()` and `Worker.claim_filter_sql()`, two hooks a
   subclass overrides to narrow what it may claim. The condition is applied
   inside the candidate select on all three claim paths, ahead of its
@@ -350,6 +350,7 @@ Initial release.
   the public API surface, the pre-1.0 SemVer rule, the deprecation
   window, and the supported Python and Django matrix.
 
+[0.4.0]: https://github.com/oxpull/django-ox/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/oxpull/django-ox/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/oxpull/django-ox/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/oxpull/django-ox/releases/tag/v0.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `WORKER_CLASS` in a backend's `OPTIONS`: the dotted path of the `Worker`
+  subclass `ox_worker` runs. Resolved from settings rather than from the
+  command line, so every child `ox_worker --processes N` starts runs the
+  same worker as the parent.
+- `Worker.claim_filter_q()` and `Worker.claim_filter_sql()`, two hooks a
+  subclass overrides to narrow what it may claim. The condition is applied
+  inside the candidate select on all three claim paths, ahead of its
+  ordering and its limit, so a narrowed worker still claims runnable work
+  behind rows it declines. Overriding `_ready_queryset()` reached only two
+  of the three paths and did nothing at all on PostgreSQL. Both hooks
+  return nothing by default and the emitted SQL is unchanged without them.
+
 ## [0.3.1] - 2026-08-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `WORKER_CLASS` in a backend's `OPTIONS`: the dotted path of the `Worker`
   subclass `ox_worker` runs. Resolved from settings rather than from the
   command line, so a worker chosen here is the worker in every child
-  process under `ox_worker --processes N`, not only in the parent.
+  process under `ox_worker --processes N`, not only at `--processes 1`.
 - `Worker.claim_filter_q()` and `Worker.claim_filter_sql()`, two hooks a
   subclass overrides to narrow what it may claim. The condition is applied
   inside the candidate select on all three claim paths, ahead of its
   ordering and its limit, so a narrowed worker still claims runnable work
-  behind rows it declines. Overriding `_ready_queryset()` reached only two
-  of the three paths and did nothing at all on PostgreSQL. Both hooks
-  return nothing by default and the emitted SQL is unchanged without them.
+  behind rows it declines. `claim_filter_q()` covers the two paths that
+  build a queryset and `claim_filter_sql()` the PostgreSQL claim, which
+  builds its own SQL, so implement both. The defaults are `None` and an
+  empty fragment, so the emitted SQL is unchanged without them.
 
 ## [0.3.1] - 2026-08-24
 
@@ -86,22 +87,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   log events: `task_timed_out`, `task_stuck`, `worker_recycling`,
   `worker_process_recycled` and `timeouts_backstop_only`.
 - `ox_worker --processes N`. Above 1, the command supervises N copies of
-  itself, each a full worker with its own database connections, lease
-  renewal, reaper and `--concurrency` thread pool, so `--processes 2
-  --concurrency 4` runs eight tasks at once. Every worker id ends in its slot
-  number. SIGTERM, SIGINT or SIGHUP to the supervisor is forwarded once and
-  the supervisor exits 0 when every worker drained, or with the first
-  non-zero code; a second signal is the force-exit, and a worker that has
-  not exited five seconds later is SIGKILLed. A worker process that dies,
-  by any exit code, is restarted with `worker_process_restarted` at
-  WARNING, after one second and then with a doubling delay up to 30
-  seconds; more than five deaths of one slot in a minute stops the
-  supervisor with exit code 1 and `supervisor_restart_cap` at ERROR. A
-  worker whose supervisor dies drains and exits (`worker_orphaned`). The
-  children are started the way the supervisor was, `manage.py` by absolute
-  path or `python -m django`, with `--settings` and `--pythonpath` passed
-  on, so the command works from any working directory. `--processes 1`, the
-  default, is the worker as before. POSIX only.
+  itself, each a full worker with its own database connections, lease renewal,
+  reaper and `--concurrency` thread pool, so `--processes 2 --concurrency 4`
+  runs eight tasks at once. Every worker id ends in its slot number. SIGTERM,
+  SIGINT or SIGHUP to the supervisor is forwarded once and the supervisor exits
+  0 when every worker drained or recycled, or with the first other non-zero
+  code; a second signal is the force-exit, and a worker that has not exited
+  five seconds later is SIGKILLed. A worker process that dies is restarted with
+  `worker_process_restarted` at WARNING, after one second and then with a
+  doubling delay up to 30 seconds; a worker that recycled itself, exit code 75,
+  comes back after one second under `worker_process_recycled`, outside the
+  death count and the backoff. More than five deaths of one slot in a minute
+  stops the supervisor with exit code 1 and `supervisor_restart_cap` at ERROR.
+  A worker whose supervisor dies drains and exits (`worker_orphaned`). The
+  children are started the way the supervisor was, `manage.py` by absolute path
+  or `python -m django`, with `--settings` and `--pythonpath` passed on, so the
+  command works from any working directory. `--processes 1`, the default, is
+  the worker as before. POSIX only.
 - A Prometheus endpoint. `path("ox/", include("django_ox.urls"))` mounts
   `GET /ox/metrics`, which renders the `django_ox.stats` numbers as gauges in
   the Prometheus text format (OpenMetrics on request), from the standard
@@ -156,8 +158,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   django_ox` when you upgrade. It adds the new status choice.
 - `QueueStats` has a sixth field, `discarded`, keyword-defaulted like `lost`.
 - A queued task can now be discarded and a failed or lost one retried, and
-  every attempt can be bounded with `TASK_TIMEOUT`; interrupting one chosen
-  running task on demand stays outside scope.
+  every attempt can be bounded with `TASK_TIMEOUT`.
 - A worker that is already draining, because it is recycling, treats the
   operator's first signal as the drain it is doing rather than as the
   force-exit; the second signal is still the force-exit.
@@ -166,12 +167,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- A task that succeeded after its lease was lost no longer keeps the reaper's
-  lost-lease record in `errors`. That record says the outcome was never
-  observed, and the success write is that observation, so anything reading
-  `result.errors` was handed an exception nobody raised on a task that worked.
-  A failure resolving the same way already dropped it, and the two now agree. A task that is still LOST keeps the record: it is
-  the only thing on the row that says why the result reads as failed.
+- A task that succeeds after its lease was lost drops the reaper's
+  lost-lease record from `errors`. That record says the outcome was never
+  observed, and the success write is that observation, so nothing reading
+  `result.errors` is handed an exception nobody raised. Every earlier
+  attempt's traceback stays on the row. A failure resolving the same way
+  already dropped it, and the two now agree. A task that is still LOST
+  keeps the record: it is the only thing on the row that says why the
+  result reads as failed.
 
 ### Added
 
@@ -193,11 +196,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that number in its WHERE clause, so a write from a worker that no longer
   holds the task matches nothing and is dropped instead of applied. No
   completion is signalled for a dropped write.
-- The reaper no longer records a failure it did not observe. When a lock aged
-  out with no attempts left it wrote FAILED and invented a `TaskAbandoned`
-  exception to explain it, on no evidence beyond a clock. It now records the
-  task as LOST, which says the worker stopped reporting and the outcome was
-  never seen, and nothing more.
+- A lock that ages out with no attempts left is recorded as LOST rather than
+  FAILED. LOST says the worker stopped reporting and the outcome was never
+  seen, and nothing more. The `TaskAbandoned` record the reaper leaves in
+  `errors` is the lost lease, not a cause of failure.
 - Lock timestamps are written and compared using the database server's clock
   rather than each worker's own, so two hosts with drifting clocks no longer
   produce false reclaims. This applies when `USE_TZ` is on. With `USE_TZ` off
@@ -310,7 +312,7 @@ Initial release.
 - `ox_prune` management command: batched deletion of finished task rows
   (`--older-than`, `--include-failed`, `--batch-size`, `--dry-run`).
 - `django_ox.stats`: read-only queue metrics as plain ORM queries, on
-  both supported databases: per-queue status counts, backlog depth and
+  every supported database: per-queue status counts, backlog depth and
   age, throughput and failure rate over a trailing window, and time
   since the last task claim.
 - `ox_health` management command: exits non-zero with a one-line reason

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ scope: interrupting one chosen running task on demand (every attempt can be
 bounded with `TASK_TIMEOUT`), and multi-database routing (tasks are stored on
 the default database for the model).
 
-Batches and unique tasks are in
+Batches, unique tasks and rate limiting are in
 [Oxpull Pro](https://oxpull.com/django-ox/pro/), a paid add-on that is not on
 sale yet; the waitlist is at <https://oxpull.com/>. Metrics stay in this
 package: `django_ox.stats` and `ox_health` are free and stay free.

--- a/benchmarks/bench.py
+++ b/benchmarks/bench.py
@@ -230,11 +230,9 @@ def migrate(backend_name: str) -> None:
 def truncate(backend_name: str) -> None:
     # CASCADE because oxscheduletick carries a nullable foreign key to
     # oxtask, and PostgreSQL refuses to truncate a table another one
-    # references even when the referencing table is empty. The schedules
-    # table arrived in migration 0002, after the 2026-08-13 numbers were
-    # taken, so a plain TRUNCATE had nothing to trip over then and has
-    # been unable to run since. Both benchmark databases exist only for
-    # this harness, so cascading is a reset, not a loss.
+    # references even when the referencing table is empty. Both benchmark
+    # databases exist only for this harness, so cascading is a reset, not
+    # a loss.
     cfg = BACKENDS[backend_name]
     with pg_connect(cfg["database"]) as conn:
         conn.execute(f'TRUNCATE "{cfg["table"]}" CASCADE')
@@ -499,12 +497,12 @@ def orchestrate(runs: int, smoke: bool = False, resume: bool = False) -> None:
                 checkpoint()
 
             if name == "ox" and not have("e2e_diagnostic", run=run):
-                # Diagnostic row, NOT part of the defaults comparison: the
-                # default worker loop sleeps its full poll interval whenever
-                # the single executor slot is momentarily busy, which caps
-                # concurrency-1 throughput near 1/interval for fast tasks.
-                # This run lowers --interval to 0.1 purely to confirm that
-                # diagnosis; the defaults row above is the honest headline.
+                # Diagnostic row, NOT part of the defaults comparison. The
+                # worker wakes as soon as an in-flight task settles, so the
+                # poll interval governs only how often an idle worker looks
+                # for new work. This run repeats concurrency 1 with
+                # --interval 0.1 to check that property on every run: it
+                # should match the default-interval cell above.
                 print(
                     f"[run {run}] {name}: DIAGNOSTIC end-to-end {E2E_COUNT} tasks, "
                     "concurrency 1, --interval 0.1 (non-default)..."

--- a/benchmarks/bench.py
+++ b/benchmarks/bench.py
@@ -228,9 +228,16 @@ def migrate(backend_name: str) -> None:
 
 
 def truncate(backend_name: str) -> None:
+    # CASCADE because oxscheduletick carries a nullable foreign key to
+    # oxtask, and PostgreSQL refuses to truncate a table another one
+    # references even when the referencing table is empty. The schedules
+    # table arrived in migration 0002, after the 2026-08-13 numbers were
+    # taken, so a plain TRUNCATE had nothing to trip over then and has
+    # been unable to run since. Both benchmark databases exist only for
+    # this harness, so cascading is a reset, not a loss.
     cfg = BACKENDS[backend_name]
     with pg_connect(cfg["database"]) as conn:
-        conn.execute(f'TRUNCATE "{cfg["table"]}"')
+        conn.execute(f'TRUNCATE "{cfg["table"]}" CASCADE')
 
 
 def count_status(backend_name: str, status: str) -> int:

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -159,8 +159,9 @@ TASKS = {
   bounds every attempt. Tasks live on the default database.
 - In tests use `django.tasks.backends.immediate.ImmediateBackend` or
   `django.tasks.backends.dummy.DummyBackend` for `TASKS`.
-- Batches and unique tasks are in [Oxpull Pro](pro.md), a paid add-on that
-  is not on sale yet. `django_ox.stats` and `ox_health` are in django-ox.
+- Batches, unique tasks and rate limiting are in [Oxpull Pro](pro.md), a
+  paid add-on that is not on sale yet. `django_ox.stats` and `ox_health`
+  are in django-ox.
 
 ## How to verify it works
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -61,13 +61,13 @@ than a changed claim.
   sub-millisecond round trips. Real deployments have network latency
   between app and database, which changes end-to-end numbers materially
   and increases the weight of per-task statement count.
-- **The concurrency-4 comparison is imperfect by construction.**
-  django-tasks-db's worker has no concurrency option, so its
-  "concurrency 4" is four separate processes: four interpreters without a
-  shared GIL, four Django boots inside the timed window. django-ox's is
-  four threads in one process. This is the fairest available mapping, though
-  still an approximation. (It also means django-ox wins that cell
-  while sharing one interpreter.)
+- **Two different shapes at concurrency 4.** django-tasks-db's worker has
+  no concurrency option, so its "concurrency 4" is four separate
+  processes: four interpreters without a shared GIL, four Django boots
+  inside the timed window. django-ox's is four threads in one process.
+  This is the fairest available mapping, and the two differences pull in
+  opposite directions: the first helps django-tasks-db, the second costs
+  it.
 - **Small N.** 2,000 tasks and 500 latency samples separate the backends
   here but say nothing about p99+ tails or sustained load. Sustained load
   and worker-failure behavior are covered separately by the
@@ -103,10 +103,11 @@ measured 0.1.0, which predates the lease fencing added in 0.2.0.
 
 ## What to take from this
 
-The shipped worker beats the reference implementation on every measured
-cell or ties it, and holds its documented guarantees under sustained load
-and repeated worker kills. But throughput on no-op tasks is not why you
-choose django-ox. The claim is the durability construction: transactional
-enqueue, at-least-once execution with a reaper, bounded retries with
-per-attempt tracebacks. The benchmark exists to show that choosing those
-semantics costs you nothing on worker performance.
+On the 0.1.0 matrix above, django-ox leads django-tasks-db on enqueue
+throughput and concurrency-1 end-to-end in all three runs. Under
+sustained load and repeated worker kills, django-ox 0.3.1 held its
+documented guarantees. But throughput on no-op tasks is not why you
+choose django-ox. The claim is the durability construction:
+transactional enqueue, at-least-once execution with a reaper, bounded
+retries with per-attempt tracebacks. The benchmark exists to show that
+on this workload those semantics cost no throughput.

--- a/docs/index.md
+++ b/docs/index.md
@@ -175,9 +175,10 @@ decisions worth knowing before you commit:
   processes under one supervisor. See
   [Production](production.md#threads-and-processes).
 
-Batches and unique tasks are in [Oxpull Pro](pro.md), a paid add-on that is
-not on sale yet; the waitlist is at <https://oxpull.com/>. Metrics stay in
-this package: `django_ox.stats` and `ox_health` are free and stay free.
+Batches, unique tasks and rate limiting are in [Oxpull Pro](pro.md), a paid
+add-on that is not on sale yet; the waitlist is at <https://oxpull.com/>.
+Metrics stay in this package: `django_ox.stats` and `ox_health` are free and
+stay free.
 
 ## License
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -182,9 +182,10 @@ decisions worth knowing before you commit:
   processes under one supervisor. See
   [Production](production.md#threads-and-processes).
 
-Batches and unique tasks are in [Oxpull Pro](pro.md), a paid add-on that is
-not on sale yet; the waitlist is at <https://oxpull.com/>. Metrics stay in
-this package: `django_ox.stats` and `ox_health` are free and stay free.
+Batches, unique tasks and rate limiting are in [Oxpull Pro](pro.md), a paid
+add-on that is not on sale yet; the waitlist is at <https://oxpull.com/>.
+Metrics stay in this package: `django_ox.stats` and `ox_health` are free and
+stay free.
 
 ## License
 
@@ -895,10 +896,10 @@ to exercise claiming and retries for real.
 
 ## Not in the core
 
-Batches and unique or deduplicated tasks are in [Oxpull Pro](pro.md), a paid
-add-on that is not on sale yet. Metrics are in the free tier: `django_ox.stats`
-and `manage.py ox_health` ship in the core. Chains and workflows are on the
-Pro roadmap, undated.
+Batches, unique or deduplicated tasks, and rate limiting are in
+[Oxpull Pro](pro.md), a paid add-on that is not on sale yet. Metrics are in the
+free tier: `django_ox.stats` and `manage.py ox_health` ship in the core. Chains
+and workflows are on the Pro roadmap, undated.
 
 ---
 
@@ -2417,8 +2418,8 @@ the pre-1.0 rule applies:
 - **0.x.y patch releases are bug fixes only** and never break a public
   surface.
 
-Pin accordingly: `django-ox~=0.3.1` accepts patch releases only;
-`django-ox>=0.3,<0.4` accepts the current minor line.
+Pin accordingly: `django-ox~=0.4.0` accepts patch releases only;
+`django-ox>=0.4,<0.5` accepts the current minor line.
 
 Once 1.0 ships, breaking changes to the public API will require a major
 version bump, in the usual SemVer way.
@@ -2486,18 +2487,25 @@ below is how to hear when it opens.
   the task rows rather than by counting signals, so a worker dying mid-task
   cannot strand a batch: the reconciler picks it up on the next tick.
 - **Rate limiting.** Cap how often a task starts. A named limit of N
-  admissions per period is declared on the task or in settings, and every
-  worker shares it through one row in the database. A throttled task stays
-  READY: it is not claimed, so it spends no retry attempt and holds no
-  lease. With one worker process the cap is exact, at most N per window.
-  With W worker processes at most N + W - 1 attempts start in a window,
-  and since windows are contiguous, an arbitrary interval of one period
-  can carry up to 2(N + W - 1).
+  admissions per period is declared in settings, and every worker shares
+  it through one row in the database. A throttled task stays READY: it is
+  not claimed, so it spends no retry attempt and holds no lease.
 
-All three run on the databases the free tier tests in CI: SQLite, PostgreSQL
-and MySQL 8. MariaDB 10.6+ takes the same claim path but is not part of the tested
-matrix. Batches have been measured to 100,000 members in a single batch on
-SQLite and on PostgreSQL 16.
+  For a limit of N admissions per period P, with W `ox_worker` processes
+  claiming from the queues that carry the limit's tasks, the number of
+  task attempts started in any one window is at most N + W - 1. Add one
+  for each worker process that dies between claiming a limited task and
+  recording it. With a single worker process and no such death the
+  limiter is exact: at most N per window. Windows are contiguous, so an
+  arbitrary interval of length P that spans a boundary can carry up to
+  2(N + W - 1). A limit whose counter cannot be written stops admitting
+  rather than admitting without counting: three consecutive failed counts
+  close it until one succeeds.
+
+All three run on the databases the free tier tests in CI: SQLite,
+PostgreSQL and MySQL 8. MariaDB 10.6+ takes the same claim path but is not
+part of the tested matrix. Batches have been measured to 100,000 members
+in a single batch on SQLite and on PostgreSQL 16.
 
 ## What Pro is not
 
@@ -2693,8 +2701,9 @@ TASKS = {
   bounds every attempt. Tasks live on the default database.
 - In tests use `django.tasks.backends.immediate.ImmediateBackend` or
   `django.tasks.backends.dummy.DummyBackend` for `TASKS`.
-- Batches and unique tasks are in [Oxpull Pro](pro.md), a paid add-on that
-  is not on sale yet. `django_ox.stats` and `ox_health` are in django-ox.
+- Batches, unique tasks and rate limiting are in [Oxpull Pro](pro.md), a
+  paid add-on that is not on sale yet. `django_ox.stats` and `ox_health`
+  are in django-ox.
 
 ## How to verify it works
 
@@ -2758,14 +2767,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.0] - 2026-09-01
 
 ### Added
 
 - `WORKER_CLASS` in a backend's `OPTIONS`: the dotted path of the `Worker`
   subclass `ox_worker` runs. Resolved from settings rather than from the
-  command line, so every child `ox_worker --processes N` starts runs the
-  same worker as the parent.
+  command line, so a worker chosen here is the worker in every child
+  process under `ox_worker --processes N`, not only in the parent.
 - `Worker.claim_filter_q()` and `Worker.claim_filter_sql()`, two hooks a
   subclass overrides to narrow what it may claim. The condition is applied
   inside the candidate select on all three claim paths, ahead of its
@@ -3103,6 +3112,7 @@ Initial release.
   the public API surface, the pre-1.0 SemVer rule, the deprecation
   window, and the supported Python and Django matrix.
 
+[0.4.0]: https://github.com/oxpull/django-ox/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/oxpull/django-ox/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/oxpull/django-ox/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/oxpull/django-ox/releases/tag/v0.2.1

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2504,8 +2504,16 @@ below is how to hear when it opens.
 
 All three run on the databases the free tier tests in CI: SQLite,
 PostgreSQL and MySQL 8. MariaDB 10.6+ takes the same claim path but is not
-part of the tested matrix. Batches have been measured to 100,000 members
-in a single batch on SQLite and on PostgreSQL 16.
+part of the tested matrix. Batches have been measured to 1,000,000 members
+in a single batch on all three, with every count checked against the task
+rows rather than against what the API reports about itself.
+
+Sealing a batch that wide is cheap on SQLite and PostgreSQL and expensive
+on MySQL: about 34 ms, 0.7 s and 28 s respectively. Sealing takes a row
+lock per member on any database that offers one, and a million InnoDB
+locks in a single transaction is what that costs. Reconciling the same
+batch is 0.4 s on PostgreSQL 16, 4.9 s on SQLite and 7.3 s on MySQL,
+against a reconciler that runs on a one-minute tick.
 
 ## What Pro is not
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2340,14 +2340,20 @@ announced in the [changelog](changelog.md). This page, not a module's
   string in the `TASKS` setting, `QUEUES` beside `OPTIONS`, and every
   `OPTIONS` key it reads: `MAX_ATTEMPTS`, `LOCK_TIMEOUT`,
   `BACKOFF_INITIAL`, `BACKOFF_MAX`, `TASK_TIMEOUT`, `TASK_TIMEOUTS`,
-  `TASK_TIMEOUT_GRACE`, and `SCHEDULES` (with its documented
-  per-schedule keys).
+  `TASK_TIMEOUT_GRACE`, `SCHEDULES` (with its documented per-schedule
+  keys), and `WORKER_CLASS`, the dotted path of the `Worker` subclass
+  `ox_worker` runs.
 - **The management commands** and their flags: `ox_worker`, `ox_prune`,
   `ox_health`. `ox_worker`'s exit codes: 0 after a drain, 130 on a forced
   exit, 75 when the worker recycles itself after a stuck task thread.
   Under `--processes`, the supervisor exits 0 when every worker drained
   or recycled, 1 when a slot hit the restart cap, and otherwise with the
   first other non-zero worker code.
+- **The claim filter hooks** `Worker.claim_filter_q()` and
+  `Worker.claim_filter_sql()`, and where their result is applied: the
+  fragment is conjoined to the conditions the candidate select filters on,
+  ahead of its ordering and its limit. The statement around it is not
+  promised.
 - **The timeout helpers** `django_ox.deadline()` and `django_ox.remaining()`,
   callable from inside a task.
 - **The metrics module** `django_ox.stats`: `queue_stats`, `ready_count`,
@@ -2464,10 +2470,10 @@ graceful drain, priorities, deferred tasks, recurring tasks and pruning are
 the free tier, permanently. Nothing that works today moves behind the paid
 tier.
 
-**Oxpull Pro** is a paid add-on for two problems that show up once a queue is
-carrying real volume. Both are built and tested. It is not on sale yet: the
-purchase and delivery path is still being set up, and the waitlist below is
-how to hear when it opens.
+**Oxpull Pro** is a paid add-on for three problems that show up once a queue
+is carrying real volume. All three are built and tested. It is not on sale
+yet: the purchase and delivery path is still being set up, and the waitlist
+below is how to hear when it opens.
 
 ## What Pro adds
 
@@ -2479,18 +2485,27 @@ how to hear when it opens.
   callback once every member has settled. Completion is computed by querying
   the task rows rather than by counting signals, so a worker dying mid-task
   cannot strand a batch: the reconciler picks it up on the next tick.
+- **Rate limiting.** Cap how often a task starts. A named limit of N
+  admissions per period is declared on the task or in settings, and every
+  worker shares it through one row in the database. A throttled task stays
+  READY: it is not claimed, so it spends no retry attempt and holds no
+  lease. With one worker process the cap is exact, at most N per window.
+  With W worker processes at most N + W - 1 attempts start in a window,
+  and since windows are contiguous, an arbitrary interval of one period
+  can carry up to 2(N + W - 1).
 
-Both run on the databases the free tier tests in CI: SQLite, PostgreSQL and
-MySQL 8. MariaDB 10.6+ takes the same claim path but is not part of the tested
+All three run on the databases the free tier tests in CI: SQLite, PostgreSQL
+and MySQL 8. MariaDB 10.6+ takes the same claim path but is not part of the tested
 matrix. Batches have been measured to 100,000 members in a single batch on
 SQLite and on PostgreSQL 16.
 
 ## What Pro is not
 
-Workflows and chains are on the roadmap, undated. Rate limiting, a web
-dashboard and encrypted payloads are not in Pro and are not dated. Metrics
-stay free: the stats API and the health command are in the open source
-package and remain there.
+Workflows and chains are on the roadmap, undated. A web dashboard and
+encrypted payloads are not in Pro and are not dated. Rate limiting caps how
+often a task starts, not how many run at once; concurrency limiting is a
+different mechanism and is not in Pro. Metrics stay free: the stats API and
+the health command are in the open source package and remain there.
 
 ## Delivery
 
@@ -2508,7 +2523,7 @@ organisation and every environment, with a seven-day money-back period.
 ## Waitlist
 
 If Pro would earn its keep in your deployment, join the waitlist and say which
-of the two features matters to you. That ordering decides what gets built
+of the three features matters to you. That ordering decides what gets built
 after these.
 
 [Join the Pro waitlist](https://oxpull.com/#waitlist){ .md-button }
@@ -2742,6 +2757,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `WORKER_CLASS` in a backend's `OPTIONS`: the dotted path of the `Worker`
+  subclass `ox_worker` runs. Resolved from settings rather than from the
+  command line, so every child `ox_worker --processes N` starts runs the
+  same worker as the parent.
+- `Worker.claim_filter_q()` and `Worker.claim_filter_sql()`, two hooks a
+  subclass overrides to narrow what it may claim. The condition is applied
+  inside the candidate select on all three claim paths, ahead of its
+  ordering and its limit, so a narrowed worker still claims runnable work
+  behind rows it declines. Overriding `_ready_queryset()` reached only two
+  of the three paths and did nothing at all on PostgreSQL. Both hooks
+  return nothing by default and the emitted SQL is unchanged without them.
 
 ## [0.3.1] - 2026-08-24
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2271,13 +2271,13 @@ than a changed claim.
   sub-millisecond round trips. Real deployments have network latency
   between app and database, which changes end-to-end numbers materially
   and increases the weight of per-task statement count.
-- **The concurrency-4 comparison is imperfect by construction.**
-  django-tasks-db's worker has no concurrency option, so its
-  "concurrency 4" is four separate processes: four interpreters without a
-  shared GIL, four Django boots inside the timed window. django-ox's is
-  four threads in one process. This is the fairest available mapping, though
-  still an approximation. (It also means django-ox wins that cell
-  while sharing one interpreter.)
+- **Two different shapes at concurrency 4.** django-tasks-db's worker has
+  no concurrency option, so its "concurrency 4" is four separate
+  processes: four interpreters without a shared GIL, four Django boots
+  inside the timed window. django-ox's is four threads in one process.
+  This is the fairest available mapping, and the two differences pull in
+  opposite directions: the first helps django-tasks-db, the second costs
+  it.
 - **Small N.** 2,000 tasks and 500 latency samples separate the backends
   here but say nothing about p99+ tails or sustained load. Sustained load
   and worker-failure behavior are covered separately by the
@@ -2313,13 +2313,14 @@ measured 0.1.0, which predates the lease fencing added in 0.2.0.
 
 ## What to take from this
 
-The shipped worker beats the reference implementation on every measured
-cell or ties it, and holds its documented guarantees under sustained load
-and repeated worker kills. But throughput on no-op tasks is not why you
-choose django-ox. The claim is the durability construction: transactional
-enqueue, at-least-once execution with a reaper, bounded retries with
-per-attempt tracebacks. The benchmark exists to show that choosing those
-semantics costs you nothing on worker performance.
+On the 0.1.0 matrix above, django-ox leads django-tasks-db on enqueue
+throughput and concurrency-1 end-to-end in all three runs. Under
+sustained load and repeated worker kills, django-ox 0.3.1 held its
+documented guarantees. But throughput on no-op tasks is not why you
+choose django-ox. The claim is the durability construction:
+transactional enqueue, at-least-once execution with a reaper, bounded
+retries with per-attempt tracebacks. The benchmark exists to show that
+on this workload those semantics cost no throughput.
 
 ---
 
@@ -2465,31 +2466,38 @@ part of the tested matrix.
 
 # Pro
 
-Everything documented on this site is free, open source (BSD 3-Clause), and
-stays that way. The durable queue, transactional enqueue, retries, reaper,
-graceful drain, priorities, deferred tasks, recurring tasks and pruning are
-the free tier, permanently. Nothing that works today moves behind the paid
-tier.
+django-ox is free, open source (BSD 3-Clause), and stays that way. The
+durable queue, transactional enqueue, retries, reaper, graceful drain,
+priorities, deferred tasks, recurring tasks and pruning are the free tier,
+permanently. Nothing that works today moves behind the paid tier.
 
 **Oxpull Pro** is a paid add-on for three problems that show up once a queue
 is carrying real volume. All three are built and tested. It is not on sale
-yet: the purchase and delivery path is still being set up, and the waitlist
-below is how to hear when it opens.
+yet. The waitlist below is how to hear when it opens.
 
 ## What Pro adds
 
-- **Unique tasks.** Deduplicate at enqueue time, so the same job cannot be
-  queued twice. The lock is written in the same transaction as the task, so
-  the two commit or roll back together, and a lock whose task died is
-  released rather than stranded.
+- **Unique tasks.** Deduplicate at enqueue time: while a task with the same
+  key is READY or RUNNING, enqueueing it again returns the pending task's
+  result rather than inserting a second row. The lock is written in the
+  same transaction as the task, so the two commit or roll back together,
+  and a lock whose task settled or was pruned is released rather than
+  stranded.
+  A bulk enqueue is one INSERT that the deduplicating path never sees, so
+  `enqueue_many()` raises `InvalidTask` for a unique task and names it.
 - **Batches.** Enqueue a group, read its progress as a count, and fire a
   callback once every member has settled. Completion is computed by querying
   the task rows rather than by counting signals, so a worker dying mid-task
   cannot strand a batch: the reconciler picks it up on the next tick.
+  Batches take one setting: `oxpull.batches.reconcile` on a one-minute cron
+  in `OPTIONS["SCHEDULES"]`, run by the django-ox cron you already have.
 - **Rate limiting.** Cap how often a task starts. A named limit of N
-  admissions per period is declared in settings, and every worker shares
-  it through one row in the database. A throttled task stays READY: it is
-  not claimed, so it spends no retry attempt and holds no lease.
+  admissions per period is declared in `OPTIONS["RATE_LIMITS"]`, and every
+  worker shares it through one row in the database. A throttled task stays
+  READY: it is not claimed, so it spends no retry attempt and holds no
+  lease. Set `OPTIONS["WORKER_CLASS"]` to `oxpull.worker.OxpullWorker`, the
+  worker that applies the limits. `manage.py check` reports `oxpull.E006`
+  when a limit is configured without it.
 
   For a limit of N admissions per period P, with W `ox_worker` processes
   claiming from the queues that carry the limit's tasks, the number of
@@ -2498,9 +2506,9 @@ below is how to hear when it opens.
   recording it. With a single worker process and no such death the
   limiter is exact: at most N per window. Windows are contiguous, so an
   arbitrary interval of length P that spans a boundary can carry up to
-  2(N + W - 1). A limit whose counter cannot be written stops admitting
-  rather than admitting without counting: three consecutive failed counts
-  close it until one succeeds.
+  2(N + W - 1). A count that cannot be written is logged and the
+  attempt runs; three consecutive failed counts on one limit close it
+  until a write lands.
 
 All three run on the databases the free tier tests in CI: SQLite,
 PostgreSQL and MySQL 8. MariaDB 10.6+ takes the same claim path but is not
@@ -2512,8 +2520,12 @@ Sealing a batch that wide is cheap on SQLite and PostgreSQL and expensive
 on MySQL: about 34 ms, 0.7 s and 28 s respectively. Sealing takes a row
 lock per member on any database that offers one, and a million InnoDB
 locks in a single transaction is what that costs. Reconciling the same
-batch is 0.4 s on PostgreSQL 16, 4.9 s on SQLite and 7.3 s on MySQL,
-against a reconciler that runs on a one-minute tick.
+batch is 4.9 s on SQLite, 0.4 s on PostgreSQL and 7.3 s on MySQL, against
+a reconciler that runs on a one-minute tick.
+
+Measured on an arm64 macOS host, with SQLite on a local file in WAL mode
+at `synchronous=NORMAL`, and stock PostgreSQL 16 and MySQL 8 images in
+Docker on localhost, each width against an empty database.
 
 ## What Pro is not
 
@@ -2525,16 +2537,21 @@ the health command are in the open source package and remain there.
 
 ## Delivery
 
-Pro will install from a private package index using credentials issued per
-company. There is no licence key and no runtime check. A licence check is one
-more thing of ours that can break your production, so we did not build one.
-The credential controls access to the index rather than to code you have
-already installed, so if it lapses, what is deployed keeps running.
+Pro installs from a private package index using credentials issued per
+company. There is no licence key and no runtime check. A licence check would
+put a validation step in the path of code that has to keep running, and it
+does nothing for a company that has already paid. Nothing in the package
+phones home: no network call to us, and no telemetry. The credential controls
+access to the index rather than to code you have already installed, so if it
+lapses, what is deployed keeps running.
 
 ## Pricing
 
 Planned at **$399 per year, per company**, flat. One licence to cover a whole
-organisation and every environment, with a seven-day money-back period.
+organisation and every environment, with a seven-day money-back period. The
+term is 12 months and renews for successive 12-month terms unless you cancel.
+Cancel by writing to support@oxpull.com. Cancellation takes effect at the end
+of the period you have paid for.
 
 ## Waitlist
 
@@ -2782,14 +2799,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `WORKER_CLASS` in a backend's `OPTIONS`: the dotted path of the `Worker`
   subclass `ox_worker` runs. Resolved from settings rather than from the
   command line, so a worker chosen here is the worker in every child
-  process under `ox_worker --processes N`, not only in the parent.
+  process under `ox_worker --processes N`, not only at `--processes 1`.
 - `Worker.claim_filter_q()` and `Worker.claim_filter_sql()`, two hooks a
   subclass overrides to narrow what it may claim. The condition is applied
   inside the candidate select on all three claim paths, ahead of its
   ordering and its limit, so a narrowed worker still claims runnable work
-  behind rows it declines. Overriding `_ready_queryset()` reached only two
-  of the three paths and did nothing at all on PostgreSQL. Both hooks
-  return nothing by default and the emitted SQL is unchanged without them.
+  behind rows it declines. `claim_filter_q()` covers the two paths that
+  build a queryset and `claim_filter_sql()` the PostgreSQL claim, which
+  builds its own SQL, so implement both. The defaults are `None` and an
+  empty fragment, so the emitted SQL is unchanged without them.
 
 ## [0.3.1] - 2026-08-24
 
@@ -2856,22 +2874,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   log events: `task_timed_out`, `task_stuck`, `worker_recycling`,
   `worker_process_recycled` and `timeouts_backstop_only`.
 - `ox_worker --processes N`. Above 1, the command supervises N copies of
-  itself, each a full worker with its own database connections, lease
-  renewal, reaper and `--concurrency` thread pool, so `--processes 2
-  --concurrency 4` runs eight tasks at once. Every worker id ends in its slot
-  number. SIGTERM, SIGINT or SIGHUP to the supervisor is forwarded once and
-  the supervisor exits 0 when every worker drained, or with the first
-  non-zero code; a second signal is the force-exit, and a worker that has
-  not exited five seconds later is SIGKILLed. A worker process that dies,
-  by any exit code, is restarted with `worker_process_restarted` at
-  WARNING, after one second and then with a doubling delay up to 30
-  seconds; more than five deaths of one slot in a minute stops the
-  supervisor with exit code 1 and `supervisor_restart_cap` at ERROR. A
-  worker whose supervisor dies drains and exits (`worker_orphaned`). The
-  children are started the way the supervisor was, `manage.py` by absolute
-  path or `python -m django`, with `--settings` and `--pythonpath` passed
-  on, so the command works from any working directory. `--processes 1`, the
-  default, is the worker as before. POSIX only.
+  itself, each a full worker with its own database connections, lease renewal,
+  reaper and `--concurrency` thread pool, so `--processes 2 --concurrency 4`
+  runs eight tasks at once. Every worker id ends in its slot number. SIGTERM,
+  SIGINT or SIGHUP to the supervisor is forwarded once and the supervisor exits
+  0 when every worker drained or recycled, or with the first other non-zero
+  code; a second signal is the force-exit, and a worker that has not exited
+  five seconds later is SIGKILLed. A worker process that dies is restarted with
+  `worker_process_restarted` at WARNING, after one second and then with a
+  doubling delay up to 30 seconds; a worker that recycled itself, exit code 75,
+  comes back after one second under `worker_process_recycled`, outside the
+  death count and the backoff. More than five deaths of one slot in a minute
+  stops the supervisor with exit code 1 and `supervisor_restart_cap` at ERROR.
+  A worker whose supervisor dies drains and exits (`worker_orphaned`). The
+  children are started the way the supervisor was, `manage.py` by absolute path
+  or `python -m django`, with `--settings` and `--pythonpath` passed on, so the
+  command works from any working directory. `--processes 1`, the default, is
+  the worker as before. POSIX only.
 - A Prometheus endpoint. `path("ox/", include("django_ox.urls"))` mounts
   `GET /ox/metrics`, which renders the `django_ox.stats` numbers as gauges in
   the Prometheus text format (OpenMetrics on request), from the standard
@@ -2926,8 +2945,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   django_ox` when you upgrade. It adds the new status choice.
 - `QueueStats` has a sixth field, `discarded`, keyword-defaulted like `lost`.
 - A queued task can now be discarded and a failed or lost one retried, and
-  every attempt can be bounded with `TASK_TIMEOUT`; interrupting one chosen
-  running task on demand stays outside scope.
+  every attempt can be bounded with `TASK_TIMEOUT`.
 - A worker that is already draining, because it is recycling, treats the
   operator's first signal as the drain it is doing rather than as the
   force-exit; the second signal is still the force-exit.
@@ -2936,12 +2954,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- A task that succeeded after its lease was lost no longer keeps the reaper's
-  lost-lease record in `errors`. That record says the outcome was never
-  observed, and the success write is that observation, so anything reading
-  `result.errors` was handed an exception nobody raised on a task that worked.
-  A failure resolving the same way already dropped it, and the two now agree. A task that is still LOST keeps the record: it is
-  the only thing on the row that says why the result reads as failed.
+- A task that succeeds after its lease was lost drops the reaper's
+  lost-lease record from `errors`. That record says the outcome was never
+  observed, and the success write is that observation, so nothing reading
+  `result.errors` is handed an exception nobody raised. Every earlier
+  attempt's traceback stays on the row. A failure resolving the same way
+  already dropped it, and the two now agree. A task that is still LOST
+  keeps the record: it is the only thing on the row that says why the
+  result reads as failed.
 
 ### Added
 
@@ -2963,11 +2983,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that number in its WHERE clause, so a write from a worker that no longer
   holds the task matches nothing and is dropped instead of applied. No
   completion is signalled for a dropped write.
-- The reaper no longer records a failure it did not observe. When a lock aged
-  out with no attempts left it wrote FAILED and invented a `TaskAbandoned`
-  exception to explain it, on no evidence beyond a clock. It now records the
-  task as LOST, which says the worker stopped reporting and the outcome was
-  never seen, and nothing more.
+- A lock that ages out with no attempts left is recorded as LOST rather than
+  FAILED. LOST says the worker stopped reporting and the outcome was never
+  seen, and nothing more. The `TaskAbandoned` record the reaper leaves in
+  `errors` is the lost lease, not a cause of failure.
 - Lock timestamps are written and compared using the database server's clock
   rather than each worker's own, so two hosts with drifting clocks no longer
   produce false reclaims. This applies when `USE_TZ` is on. With `USE_TZ` off
@@ -3080,7 +3099,7 @@ Initial release.
 - `ox_prune` management command: batched deletion of finished task rows
   (`--older-than`, `--include-failed`, `--batch-size`, `--dry-run`).
 - `django_ox.stats`: read-only queue metrics as plain ORM queries, on
-  both supported databases: per-queue status counts, backlog depth and
+  every supported database: per-queue status counts, backlog depth and
   age, throughput and failure rate over a trailing window, and time
   since the last task claim.
 - `ox_health` management command: exits non-zero with a one-line reason

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -121,10 +121,10 @@ Operational facts worth getting right:
   routing (tasks live on the default database). For tests, point `TASKS` at
   `django.tasks.backends.immediate.ImmediateBackend` or
   `django.tasks.backends.dummy.DummyBackend`.
-- Batches and unique (deduplicated) tasks are in Oxpull Pro, a paid add-on
-  that is not on sale yet, delivered from a private package index when it
-  opens. They are not in django-ox. `django_ox.stats` and `ox_health` are in
-  the free package.
+- Batches, unique (deduplicated) tasks and rate limiting are in Oxpull Pro,
+  a paid add-on that is not on sale yet, delivered from a private package
+  index when it opens. They are not in django-ox. `django_ox.stats` and
+  `ox_health` are in the free package.
 
 ## Documentation
 

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -263,7 +263,7 @@ to exercise claiming and retries for real.
 
 ## Not in the core
 
-Batches and unique or deduplicated tasks are in [Oxpull Pro](pro.md), a paid
-add-on that is not on sale yet. Metrics are in the free tier: `django_ox.stats`
-and `manage.py ox_health` ship in the core. Chains and workflows are on the
-Pro roadmap, undated.
+Batches, unique or deduplicated tasks, and rate limiting are in
+[Oxpull Pro](pro.md), a paid add-on that is not on sale yet. Metrics are in the
+free tier: `django_ox.stats` and `manage.py ox_health` ship in the core. Chains
+and workflows are on the Pro roadmap, undated.

--- a/docs/pro.md
+++ b/docs/pro.md
@@ -22,18 +22,25 @@ below is how to hear when it opens.
   the task rows rather than by counting signals, so a worker dying mid-task
   cannot strand a batch: the reconciler picks it up on the next tick.
 - **Rate limiting.** Cap how often a task starts. A named limit of N
-  admissions per period is declared on the task or in settings, and every
-  worker shares it through one row in the database. A throttled task stays
-  READY: it is not claimed, so it spends no retry attempt and holds no
-  lease. With one worker process the cap is exact, at most N per window.
-  With W worker processes at most N + W - 1 attempts start in a window,
-  and since windows are contiguous, an arbitrary interval of one period
-  can carry up to 2(N + W - 1).
+  admissions per period is declared in settings, and every worker shares
+  it through one row in the database. A throttled task stays READY: it is
+  not claimed, so it spends no retry attempt and holds no lease.
 
-All three run on the databases the free tier tests in CI: SQLite, PostgreSQL
-and MySQL 8. MariaDB 10.6+ takes the same claim path but is not part of the tested
-matrix. Batches have been measured to 100,000 members in a single batch on
-SQLite and on PostgreSQL 16.
+  For a limit of N admissions per period P, with W `ox_worker` processes
+  claiming from the queues that carry the limit's tasks, the number of
+  task attempts started in any one window is at most N + W - 1. Add one
+  for each worker process that dies between claiming a limited task and
+  recording it. With a single worker process and no such death the
+  limiter is exact: at most N per window. Windows are contiguous, so an
+  arbitrary interval of length P that spans a boundary can carry up to
+  2(N + W - 1). A limit whose counter cannot be written stops admitting
+  rather than admitting without counting: three consecutive failed counts
+  close it until one succeeds.
+
+All three run on the databases the free tier tests in CI: SQLite,
+PostgreSQL and MySQL 8. MariaDB 10.6+ takes the same claim path but is not
+part of the tested matrix. Batches have been measured to 100,000 members
+in a single batch on SQLite and on PostgreSQL 16.
 
 ## What Pro is not
 

--- a/docs/pro.md
+++ b/docs/pro.md
@@ -39,8 +39,16 @@ below is how to hear when it opens.
 
 All three run on the databases the free tier tests in CI: SQLite,
 PostgreSQL and MySQL 8. MariaDB 10.6+ takes the same claim path but is not
-part of the tested matrix. Batches have been measured to 100,000 members
-in a single batch on SQLite and on PostgreSQL 16.
+part of the tested matrix. Batches have been measured to 1,000,000 members
+in a single batch on all three, with every count checked against the task
+rows rather than against what the API reports about itself.
+
+Sealing a batch that wide is cheap on SQLite and PostgreSQL and expensive
+on MySQL: about 34 ms, 0.7 s and 28 s respectively. Sealing takes a row
+lock per member on any database that offers one, and a million InnoDB
+locks in a single transaction is what that costs. Reconciling the same
+batch is 0.4 s on PostgreSQL 16, 4.9 s on SQLite and 7.3 s on MySQL,
+against a reconciler that runs on a one-minute tick.
 
 ## What Pro is not
 

--- a/docs/pro.md
+++ b/docs/pro.md
@@ -1,30 +1,37 @@
 # Pro
 
-Everything documented on this site is free, open source (BSD 3-Clause), and
-stays that way. The durable queue, transactional enqueue, retries, reaper,
-graceful drain, priorities, deferred tasks, recurring tasks and pruning are
-the free tier, permanently. Nothing that works today moves behind the paid
-tier.
+django-ox is free, open source (BSD 3-Clause), and stays that way. The
+durable queue, transactional enqueue, retries, reaper, graceful drain,
+priorities, deferred tasks, recurring tasks and pruning are the free tier,
+permanently. Nothing that works today moves behind the paid tier.
 
 **Oxpull Pro** is a paid add-on for three problems that show up once a queue
 is carrying real volume. All three are built and tested. It is not on sale
-yet: the purchase and delivery path is still being set up, and the waitlist
-below is how to hear when it opens.
+yet. The waitlist below is how to hear when it opens.
 
 ## What Pro adds
 
-- **Unique tasks.** Deduplicate at enqueue time, so the same job cannot be
-  queued twice. The lock is written in the same transaction as the task, so
-  the two commit or roll back together, and a lock whose task died is
-  released rather than stranded.
+- **Unique tasks.** Deduplicate at enqueue time: while a task with the same
+  key is READY or RUNNING, enqueueing it again returns the pending task's
+  result rather than inserting a second row. The lock is written in the
+  same transaction as the task, so the two commit or roll back together,
+  and a lock whose task settled or was pruned is released rather than
+  stranded.
+  A bulk enqueue is one INSERT that the deduplicating path never sees, so
+  `enqueue_many()` raises `InvalidTask` for a unique task and names it.
 - **Batches.** Enqueue a group, read its progress as a count, and fire a
   callback once every member has settled. Completion is computed by querying
   the task rows rather than by counting signals, so a worker dying mid-task
   cannot strand a batch: the reconciler picks it up on the next tick.
+  Batches take one setting: `oxpull.batches.reconcile` on a one-minute cron
+  in `OPTIONS["SCHEDULES"]`, run by the django-ox cron you already have.
 - **Rate limiting.** Cap how often a task starts. A named limit of N
-  admissions per period is declared in settings, and every worker shares
-  it through one row in the database. A throttled task stays READY: it is
-  not claimed, so it spends no retry attempt and holds no lease.
+  admissions per period is declared in `OPTIONS["RATE_LIMITS"]`, and every
+  worker shares it through one row in the database. A throttled task stays
+  READY: it is not claimed, so it spends no retry attempt and holds no
+  lease. Set `OPTIONS["WORKER_CLASS"]` to `oxpull.worker.OxpullWorker`, the
+  worker that applies the limits. `manage.py check` reports `oxpull.E006`
+  when a limit is configured without it.
 
   For a limit of N admissions per period P, with W `ox_worker` processes
   claiming from the queues that carry the limit's tasks, the number of
@@ -33,9 +40,9 @@ below is how to hear when it opens.
   recording it. With a single worker process and no such death the
   limiter is exact: at most N per window. Windows are contiguous, so an
   arbitrary interval of length P that spans a boundary can carry up to
-  2(N + W - 1). A limit whose counter cannot be written stops admitting
-  rather than admitting without counting: three consecutive failed counts
-  close it until one succeeds.
+  2(N + W - 1). A count that cannot be written is logged and the
+  attempt runs; three consecutive failed counts on one limit close it
+  until a write lands.
 
 All three run on the databases the free tier tests in CI: SQLite,
 PostgreSQL and MySQL 8. MariaDB 10.6+ takes the same claim path but is not
@@ -47,8 +54,12 @@ Sealing a batch that wide is cheap on SQLite and PostgreSQL and expensive
 on MySQL: about 34 ms, 0.7 s and 28 s respectively. Sealing takes a row
 lock per member on any database that offers one, and a million InnoDB
 locks in a single transaction is what that costs. Reconciling the same
-batch is 0.4 s on PostgreSQL 16, 4.9 s on SQLite and 7.3 s on MySQL,
-against a reconciler that runs on a one-minute tick.
+batch is 4.9 s on SQLite, 0.4 s on PostgreSQL and 7.3 s on MySQL, against
+a reconciler that runs on a one-minute tick.
+
+Measured on an arm64 macOS host, with SQLite on a local file in WAL mode
+at `synchronous=NORMAL`, and stock PostgreSQL 16 and MySQL 8 images in
+Docker on localhost, each width against an empty database.
 
 ## What Pro is not
 
@@ -60,16 +71,21 @@ the health command are in the open source package and remain there.
 
 ## Delivery
 
-Pro will install from a private package index using credentials issued per
-company. There is no licence key and no runtime check. A licence check is one
-more thing of ours that can break your production, so we did not build one.
-The credential controls access to the index rather than to code you have
-already installed, so if it lapses, what is deployed keeps running.
+Pro installs from a private package index using credentials issued per
+company. There is no licence key and no runtime check. A licence check would
+put a validation step in the path of code that has to keep running, and it
+does nothing for a company that has already paid. Nothing in the package
+phones home: no network call to us, and no telemetry. The credential controls
+access to the index rather than to code you have already installed, so if it
+lapses, what is deployed keeps running.
 
 ## Pricing
 
 Planned at **$399 per year, per company**, flat. One licence to cover a whole
-organisation and every environment, with a seven-day money-back period.
+organisation and every environment, with a seven-day money-back period. The
+term is 12 months and renews for successive 12-month terms unless you cancel.
+Cancel by writing to support@oxpull.com. Cancellation takes effect at the end
+of the period you have paid for.
 
 ## Waitlist
 

--- a/docs/pro.md
+++ b/docs/pro.md
@@ -6,10 +6,10 @@ graceful drain, priorities, deferred tasks, recurring tasks and pruning are
 the free tier, permanently. Nothing that works today moves behind the paid
 tier.
 
-**Oxpull Pro** is a paid add-on for two problems that show up once a queue is
-carrying real volume. Both are built and tested. It is not on sale yet: the
-purchase and delivery path is still being set up, and the waitlist below is
-how to hear when it opens.
+**Oxpull Pro** is a paid add-on for three problems that show up once a queue
+is carrying real volume. All three are built and tested. It is not on sale
+yet: the purchase and delivery path is still being set up, and the waitlist
+below is how to hear when it opens.
 
 ## What Pro adds
 
@@ -21,18 +21,27 @@ how to hear when it opens.
   callback once every member has settled. Completion is computed by querying
   the task rows rather than by counting signals, so a worker dying mid-task
   cannot strand a batch: the reconciler picks it up on the next tick.
+- **Rate limiting.** Cap how often a task starts. A named limit of N
+  admissions per period is declared on the task or in settings, and every
+  worker shares it through one row in the database. A throttled task stays
+  READY: it is not claimed, so it spends no retry attempt and holds no
+  lease. With one worker process the cap is exact, at most N per window.
+  With W worker processes at most N + W - 1 attempts start in a window,
+  and since windows are contiguous, an arbitrary interval of one period
+  can carry up to 2(N + W - 1).
 
-Both run on the databases the free tier tests in CI: SQLite, PostgreSQL and
-MySQL 8. MariaDB 10.6+ takes the same claim path but is not part of the tested
+All three run on the databases the free tier tests in CI: SQLite, PostgreSQL
+and MySQL 8. MariaDB 10.6+ takes the same claim path but is not part of the tested
 matrix. Batches have been measured to 100,000 members in a single batch on
 SQLite and on PostgreSQL 16.
 
 ## What Pro is not
 
-Workflows and chains are on the roadmap, undated. Rate limiting, a web
-dashboard and encrypted payloads are not in Pro and are not dated. Metrics
-stay free: the stats API and the health command are in the open source
-package and remain there.
+Workflows and chains are on the roadmap, undated. A web dashboard and
+encrypted payloads are not in Pro and are not dated. Rate limiting caps how
+often a task starts, not how many run at once; concurrency limiting is a
+different mechanism and is not in Pro. Metrics stay free: the stats API and
+the health command are in the open source package and remain there.
 
 ## Delivery
 
@@ -50,7 +59,7 @@ organisation and every environment, with a seven-day money-back period.
 ## Waitlist
 
 If Pro would earn its keep in your deployment, join the waitlist and say which
-of the two features matters to you. That ordering decides what gets built
+of the three features matters to you. That ordering decides what gets built
 after these.
 
 [Join the Pro waitlist](https://oxpull.com/#waitlist){ .md-button }

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -91,8 +91,8 @@ the pre-1.0 rule applies:
 - **0.x.y patch releases are bug fixes only** and never break a public
   surface.
 
-Pin accordingly: `django-ox~=0.3.1` accepts patch releases only;
-`django-ox>=0.3,<0.4` accepts the current minor line.
+Pin accordingly: `django-ox~=0.4.0` accepts patch releases only;
+`django-ox>=0.4,<0.5` accepts the current minor line.
 
 Once 1.0 ships, breaking changes to the public API will require a major
 version bump, in the usual SemVer way.

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -14,14 +14,20 @@ announced in the [changelog](changelog.md). This page, not a module's
   string in the `TASKS` setting, `QUEUES` beside `OPTIONS`, and every
   `OPTIONS` key it reads: `MAX_ATTEMPTS`, `LOCK_TIMEOUT`,
   `BACKOFF_INITIAL`, `BACKOFF_MAX`, `TASK_TIMEOUT`, `TASK_TIMEOUTS`,
-  `TASK_TIMEOUT_GRACE`, and `SCHEDULES` (with its documented
-  per-schedule keys).
+  `TASK_TIMEOUT_GRACE`, `SCHEDULES` (with its documented per-schedule
+  keys), and `WORKER_CLASS`, the dotted path of the `Worker` subclass
+  `ox_worker` runs.
 - **The management commands** and their flags: `ox_worker`, `ox_prune`,
   `ox_health`. `ox_worker`'s exit codes: 0 after a drain, 130 on a forced
   exit, 75 when the worker recycles itself after a stuck task thread.
   Under `--processes`, the supervisor exits 0 when every worker drained
   or recycled, 1 when a slot hit the restart cap, and otherwise with the
   first other non-zero worker code.
+- **The claim filter hooks** `Worker.claim_filter_q()` and
+  `Worker.claim_filter_sql()`, and where their result is applied: the
+  fragment is conjoined to the conditions the candidate select filters on,
+  ahead of its ordering and its limit. The statement around it is not
+  promised.
 - **The timeout helpers** `django_ox.deadline()` and `django_ox.remaining()`,
   callable from inside a task.
 - **The metrics module** `django_ox.stats`: `queue_stats`, `ready_count`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-ox"
-version = "0.3.1"
+version = "0.4.0"
 description = "Database-backed worker backend for Django's Tasks framework."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/src/django_ox/__init__.py
+++ b/src/django_ox/__init__.py
@@ -1,4 +1,4 @@
 from .timeouts import deadline, remaining
 
 __all__ = ["__version__", "deadline", "remaining"]
-__version__ = "0.3.1"
+__version__ = "0.4.0"

--- a/src/django_ox/management/commands/ox_worker.py
+++ b/src/django_ox/management/commands/ox_worker.py
@@ -11,7 +11,7 @@ from django.tasks import DEFAULT_TASK_BACKEND_ALIAS
 
 from django_ox.supervisor import STOP_SIGNALS, Supervisor
 from django_ox.timeouts import RECYCLE_EXIT_CODE
-from django_ox.worker import Worker
+from django_ox.worker import worker_class
 
 logger = logging.getLogger("django_ox")
 
@@ -108,7 +108,7 @@ class Command(BaseCommand):
             if options["queues"]
             else None
         )
-        worker = Worker(
+        worker = worker_class(options["backend"])(
             backend_alias=options["backend"],
             queues=queues,
             concurrency=options["concurrency"],

--- a/src/django_ox/worker.py
+++ b/src/django_ox/worker.py
@@ -40,6 +40,7 @@ from django.tasks.signals import task_finished, task_started
 from django.utils import timezone
 from django.utils.crypto import get_random_string
 from django.utils.json import normalize_json
+from django.utils.module_loading import import_string
 
 from .backend import OxBackend
 from .exceptions import TaskAbandoned, TaskTimeout
@@ -234,7 +235,7 @@ WHERE "id" = (
     SELECT "id" FROM "{table}"
     WHERE "status" = %(ready)s
         AND ("run_after" IS NULL OR "run_after" <= %(now)s)
-        {queue_clause}
+        {queue_clause}{extra_clause}
     ORDER BY "priority" DESC, "enqueued_at"
     FOR UPDATE SKIP LOCKED
     LIMIT 1
@@ -489,6 +490,30 @@ class Worker:
 
     # -- claiming ----------------------------------------------------------
 
+    def claim_filter_q(self) -> Q | None:
+        """
+        An extra condition on what this worker may claim, or None.
+
+        Applied to the candidate queryset on the two claim paths that build
+        one. claim_filter_sql() is the same condition for the path that does
+        not. A subclass that implements one and not the other narrows two of
+        the three supported databases and silently does nothing on the third.
+        """
+        return None
+
+    def claim_filter_sql(self) -> tuple[str, dict[str, Any]]:
+        """
+        claim_filter_q() as a WHERE fragment and its parameters, for the
+        PostgreSQL claim, which builds its own SQL.
+
+        The fragment is appended to the candidate select's conditions as a
+        bare ``AND ...`` conjunct against the task table, so it carries its
+        own leading separator. That placement is the contract; the statement
+        it lands in is not. Returning ("", {}) leaves the emitted SQL
+        unchanged.
+        """
+        return "", {}
+
     def _ready_queryset(self) -> QuerySet[OxTask]:
         # run_after stays on process time, on both sides of this comparison
         # and in the retry that writes it. Database-side time is the right
@@ -504,6 +529,9 @@ class Worker:
         )
         if self.queues:
             queryset = queryset.filter(queue_name__in=self.queues)
+        extra = self.claim_filter_q()
+        if extra is not None:
+            queryset = queryset.filter(extra)
         return queryset.order_by("-priority", "enqueued_at")
 
     def _claim_fields(self, candidate: OxTask) -> dict[str, Any]:
@@ -528,8 +556,11 @@ class Worker:
         # STATEMENT_TIMESTAMP(). See _ready_queryset for why run_after is
         # the exception.
         queue_clause = 'AND "queue_name" = ANY(%(queues)s)' if self.queues else ""
+        extra_clause, extra_params = self.claim_filter_sql()
         sql = POSTGRES_CLAIM_SQL.format(
-            table=OxTask._meta.db_table, queue_clause=queue_clause
+            table=OxTask._meta.db_table,
+            queue_clause=queue_clause,
+            extra_clause=extra_clause,
         )
         rows = OxTask.objects.raw(
             sql,
@@ -540,6 +571,7 @@ class Worker:
                 "worker_id_json": json.dumps([self.worker_id]),
                 "now": run_after_cutoff,
                 "queues": self.queues,
+                **extra_params,
             },
         )
         return next(iter(rows), None)
@@ -1734,3 +1766,25 @@ class Worker:
             if len(pending) <= self._stuck_alive():
                 return
             wait(pending, timeout=RECYCLE_DRAIN_POLL, return_when=FIRST_COMPLETED)
+
+
+def worker_class(backend_alias: str = DEFAULT_TASK_BACKEND_ALIAS) -> type[Worker]:
+    """
+    The Worker class for a backend, from its OPTIONS["WORKER_CLASS"].
+
+    Resolved from settings rather than chosen by the management command,
+    because the supervisor starts every child as `ox_worker`. A worker
+    selected any other way would be the configured worker at --processes 1
+    and the default one in every child above it.
+    """
+    backend = task_backends[backend_alias]
+    path = backend.options.get("WORKER_CLASS")
+    if not path:
+        return Worker
+    cls = import_string(path)
+    if not (isinstance(cls, type) and issubclass(cls, Worker)):
+        raise ImproperlyConfigured(
+            f"WORKER_CLASS {path!r} on backend {backend_alias!r} is not a "
+            "django_ox.worker.Worker subclass."
+        )
+    return cls

--- a/tests/test_claim_filter.py
+++ b/tests/test_claim_filter.py
@@ -1,0 +1,136 @@
+import pytest
+from django.core.exceptions import ImproperlyConfigured
+from django.db.models import Q
+
+from django_ox.models import OxTask
+from django_ox.worker import POSTGRES_CLAIM_SQL, Worker, worker_class
+
+from .tasks import add, echo, send_email
+
+# What 0.3.1 emitted, spelled out rather than derived from the template: a
+# test that formatted the template twice would agree with any stray newline
+# the template grew. Written line by line because the condition line renders
+# as bare indentation when nothing filters, and an editor would strip it.
+CLAIM_SQL_0_3_1_NO_QUEUES = (
+    "\n"
+    'UPDATE "ox_task" SET\n'
+    '    "status" = %(running)s,\n'
+    '    "locked_by" = %(worker_id)s,\n'
+    '    "locked_at" = STATEMENT_TIMESTAMP(),\n'
+    '    "lease_epoch" = "lease_epoch" + 1,\n'
+    '    "attempts" = "attempts" + 1,\n'
+    '    "started_at" = COALESCE("started_at", STATEMENT_TIMESTAMP()),\n'
+    '    "last_attempted_at" = STATEMENT_TIMESTAMP(),\n'
+    '    "worker_ids" = "worker_ids" || %(worker_id_json)s::jsonb\n'
+    'WHERE "id" = (\n'
+    '    SELECT "id" FROM "ox_task"\n'
+    '    WHERE "status" = %(ready)s\n'
+    '        AND ("run_after" IS NULL OR "run_after" <= %(now)s)\n'
+    "        \n"
+    '    ORDER BY "priority" DESC, "enqueued_at"\n'
+    "    FOR UPDATE SKIP LOCKED\n"
+    "    LIMIT 1\n"
+    ")\n"
+    "RETURNING *\n"
+)
+
+CLAIM_SQL_0_3_1_WITH_QUEUES = CLAIM_SQL_0_3_1_NO_QUEUES.replace(
+    "        \n", '        AND "queue_name" = ANY(%(queues)s)\n'
+)
+
+BLOCKED_PATH = "tests.tasks.add"
+
+
+class BlockAdd(Worker):
+    """A worker that declines one task path, on every claim path."""
+
+    def claim_filter_q(self):
+        return ~Q(task_path=BLOCKED_PATH)
+
+    def claim_filter_sql(self):
+        return ' AND "task_path" <> ALL(%(blocked)s)', {"blocked": [BLOCKED_PATH]}
+
+
+class TestRenderedClaimSql:
+    def test_empty_fragment_renders_0_3_1_byte_for_byte(self):
+        assert (
+            POSTGRES_CLAIM_SQL.format(table="ox_task", queue_clause="", extra_clause="")
+            == CLAIM_SQL_0_3_1_NO_QUEUES
+        )
+        assert (
+            POSTGRES_CLAIM_SQL.format(
+                table="ox_task",
+                queue_clause='AND "queue_name" = ANY(%(queues)s)',
+                extra_clause="",
+            )
+            == CLAIM_SQL_0_3_1_WITH_QUEUES
+        )
+
+    def test_fragment_lands_inside_the_candidate_select(self):
+        sql = POSTGRES_CLAIM_SQL.format(
+            table="ox_task",
+            queue_clause="",
+            extra_clause=' AND "task_path" <> ALL(%(blocked)s)',
+        )
+        # Ahead of the ordering and the limit, so the candidate is picked
+        # from rows the fragment already accepts. Outside the subselect the
+        # statement would choose a declined head row and then discard it,
+        # claiming nothing while runnable work waited behind it.
+        assert sql.index("<> ALL") < sql.index("ORDER BY")
+
+
+@pytest.mark.django_db
+class TestClaimFilter:
+    def test_base_worker_claims_everything(self, worker):
+        add.enqueue(1, 2)
+        assert worker.claim_one() is not None
+
+    def test_filter_declines_a_path_and_claims_the_rest(self):
+        add.enqueue(1, 2)
+        echo.enqueue("kept")
+        blocking = BlockAdd(backoff_initial=0)
+
+        claimed = blocking.claim_one()
+
+        assert claimed is not None
+        assert claimed.task_path == "tests.tasks.echo"
+        assert blocking.claim_one() is None
+        # A declined row is never claimed, so it spends no attempt.
+        assert OxTask.objects.get(task_path=BLOCKED_PATH).attempts == 0
+
+    def test_filter_does_not_block_the_head_of_the_queue(self):
+        # The declined rows sort first and there are more of them than the
+        # optimistic path fetches per pass, so a filter applied after the
+        # candidates are chosen would claim nothing here.
+        for _ in range(10):
+            add.using(priority=10).enqueue(1, 2)
+        send_email.using(priority=0).enqueue("someone@example.com")
+
+        claimed = BlockAdd(backoff_initial=0).claim_one()
+
+        assert claimed is not None
+        assert claimed.task_path == "tests.tasks.send_email"
+
+
+class TestWorkerClass:
+    def test_defaults_to_worker(self):
+        assert worker_class() is Worker
+
+    def test_resolves_the_configured_path(self, settings):
+        settings.TASKS = {
+            "default": {
+                "BACKEND": "django_ox.backend.OxBackend",
+                "OPTIONS": {"WORKER_CLASS": "tests.test_claim_filter.BlockAdd"},
+            }
+        }
+        assert worker_class() is BlockAdd
+
+    def test_refuses_a_class_that_is_not_a_worker(self, settings):
+        settings.TASKS = {
+            "default": {
+                "BACKEND": "django_ox.backend.OxBackend",
+                "OPTIONS": {"WORKER_CLASS": "django_ox.models.OxTask"},
+            }
+        }
+        with pytest.raises(ImproperlyConfigured, match="is not a"):
+            worker_class()

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -95,6 +95,43 @@ def test_processes_one_never_starts_a_supervisor(recorded_worker, monkeypatch):
     assert worker.kwargs["worker_index"] is None
 
 
+def test_a_supervisor_child_runs_the_configured_worker_class(settings, monkeypatch):
+    """
+    The reason WORKER_CLASS is a setting rather than a second command.
+
+    Supervisor.child_command spawns children by the name ``ox_worker``, so a
+    worker class supplied on the parent's command line would not reach them:
+    every child above --processes 1 would silently run the stock worker. The
+    class comes from settings, which the child reads for itself, and this
+    asserts the child really does.
+    """
+    settings.TASKS = {
+        "default": {
+            "BACKEND": "django_ox.backend.OxBackend",
+            "OPTIONS": {"WORKER_CLASS": "tests.test_command.StoppedWorker"},
+        }
+    }
+    StoppedWorker.started = False
+    monkeypatch.setattr(ox_worker, "_die_with_parent", lambda: None)
+
+    with pytest.raises(SystemExit) as excinfo:
+        call_command("ox_worker", "--worker-index=0", verbosity=0)
+
+    assert excinfo.value.code == 0
+    assert StoppedWorker.started is True
+
+
+def test_the_child_command_the_supervisor_spawns_is_ox_worker(settings):
+    """
+    The other half of the pair above. If this name ever changes, the child
+    stops being the command that reads WORKER_CLASS and the test above stops
+    covering anything real.
+    """
+    from django_ox.supervisor import child_command
+
+    assert "ox_worker" in child_command([], 0, argv0="manage.py")
+
+
 def test_processes_below_one_is_rejected(recorded_worker):
     with pytest.raises(CommandError):
         call_command("ox_worker", "--processes=0", verbosity=0)

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -2,10 +2,11 @@ import pytest
 from django.core.management import CommandError, call_command
 
 from django_ox.management.commands import ox_worker
+from django_ox.worker import Worker
 
 
 class WorkerRecorder:
-    """Stands in for Worker to verify CLI flag wiring without a run loop."""
+    """Stands in for the worker class to verify CLI flag wiring without a run loop."""
 
     instances: list["WorkerRecorder"] = []
 
@@ -19,11 +20,36 @@ class WorkerRecorder:
         pass
 
 
+class StoppedWorker(Worker):
+    """Runs one pass and returns, so the command exits without a queue."""
+
+    started = False
+
+    def run(self):
+        StoppedWorker.started = True
+
+
 @pytest.fixture
 def recorded_worker(monkeypatch):
     WorkerRecorder.instances = []
-    monkeypatch.setattr(ox_worker, "Worker", WorkerRecorder)
+    monkeypatch.setattr(ox_worker, "worker_class", lambda alias: WorkerRecorder)
     return WorkerRecorder
+
+
+def test_command_runs_the_configured_worker_class(settings):
+    settings.TASKS = {
+        "default": {
+            "BACKEND": "django_ox.backend.OxBackend",
+            "OPTIONS": {"WORKER_CLASS": "tests.test_command.StoppedWorker"},
+        }
+    }
+    StoppedWorker.started = False
+
+    with pytest.raises(SystemExit) as excinfo:
+        call_command("ox_worker")
+
+    assert excinfo.value.code == 0
+    assert StoppedWorker.started is True
 
 
 def test_command_passes_flags_to_worker(recorded_worker):


### PR DESCRIPTION
Adds the seam a Worker subclass needs to narrow what it claims, and releases 0.4.0.

`WORKER_CLASS` in a backend's `OPTIONS` names the Worker subclass `ox_worker` runs. It is read
from settings rather than the command line because the supervisor starts every child as
`ox_worker`, so a worker chosen any other way would be the configured one at `--processes 1` and
the default one in every child above it. A test asserts a child runs the configured class, and a
second asserts the command the supervisor spawns is still the one that reads the setting.

`claim_filter_q()` and `claim_filter_sql()` carry the same condition to the paths that build a
queryset and the path that builds its own SQL. Both land inside the candidate select, ahead of its
ordering and its limit, so a worker that declines the head of the queue still claims runnable work
behind it. Both return nothing by default, and `tests/test_claim_filter.py` asserts the rendered
statement against the 0.3.1 SQL written out in full.

Also here:

- The benchmark resets with `TRUNCATE ... CASCADE`, which the schedule-tick foreign key requires.
- Batch width is documented to 1,000,000 members on SQLite, PostgreSQL 16 and MySQL 8, with what
  sealing costs on each.
- The Pro page lists what each feature needs to run, and states the rate-limit bound in the same
  words as the package that implements it.

Suites green on SQLite, PostgreSQL 16 and MySQL 8.
